### PR TITLE
Create oracular guest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         image:
           - guest-fedora-41
+          - guest-ubuntu-oracular
 
     steps:
       - uses: actions/checkout@v4

--- a/guest-ubuntu-oracular/mkosi.conf
+++ b/guest-ubuntu-oracular/mkosi.conf
@@ -1,0 +1,10 @@
+[Include]
+Include=../common/
+
+[Distribution]
+Distribution=ubuntu
+Release=oracular
+Repositories=universe
+
+[Content]
+Packages=linux-image-virtual,systemd,systemd-boot-efi,systemd-resolved


### PR DESCRIPTION
In the configuration file, I added universe repositories to workaround the systemd-boot issue during mkosi build
(Issue: Failed to open boot loader directory /buildroot/usr/lib/systemd/boot/efi: No such file or directory)