### PR TITLE
Fix Ubuntu Oracular QEMU boot on serial console

### DIFF
--- a/guest/ubuntu/mkosi.conf
+++ b/guest/ubuntu/mkosi.conf
@@ -6,4 +6,4 @@ Distribution=ubuntu
 Repositories=universe
 
 [Content]
-Packages=linux-image-virtual,systemd,systemd-boot-efi,systemd-resolved
+Packages=linux-image-virtual,systemd,systemd-boot-efi,systemd-resolved,plymouth


### PR DESCRIPTION
fix: Add plymouth package to fix QEMU boot on serial console