### PR TITLE
Adding guest image embedding into host image

### DIFF
--- a/modules/embed-guest-image/mkosi.build
+++ b/modules/embed-guest-image/mkosi.build
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eux
+
+# Expected: mkosi sets $DISTRIBUTION and $RELEASE (e.g. fedora and 41)
+GUEST_IMAGE_ID="guest-${DISTRIBUTION}-${RELEASE}"
+
+# Validate we have a matching guest configuration  
+GUEST_CONFIG_DIR="${SRCDIR}/images/${GUEST_IMAGE_ID}"
+
+GUEST_IMAGE_DIR="${DESTDIR}/usr/local/lib/guest-image"
+
+if [ ! -d "$GUEST_CONFIG_DIR.efi" ]; then  
+   echo "Guest Image not built, building image for embedding."
+   #Build the guest image
+   mkosi --image-id="${GUEST_IMAGE_ID}" -C "${GUEST_CONFIG_DIR}"  build  
+fi
+
+if [ ! -d "$GUEST_IMAGE_DIR" ]; then  
+   mkdir -p "${GUEST_IMAGE_DIR}"  
+fi
+
+cp -r "${SRCDIR}/images/${GUEST_IMAGE_ID}/${GUEST_IMAGE_ID}.efi" \
+   "${DESTDIR}/usr/local/lib/guest-image/guest.efi"

--- a/modules/embed-guest-image/mkosi.conf
+++ b/modules/embed-guest-image/mkosi.conf
@@ -1,0 +1,3 @@
+[Build]
+ToolsTreePackages=mkosi
+BuildSources=../../images:images,../../modules:modules

--- a/modules/host/mkosi.conf
+++ b/modules/host/mkosi.conf
@@ -1,3 +1,4 @@
 [Include]
 Include=../common
 Include=../network
+Include=../embed-guest-image


### PR DESCRIPTION
Adds a module that has a build script that will embed existing
guest-distro-release into the host image when the host image is build.

It will add the images and modules directories into the build directory,
which might make the build process a little longer, but the image size
shouldn't increase (except for adding the guest efi)

If there is no .efi image already build, it will then build it usind
mkosi and then grab it.

Waiting to merge https://github.com/AMDEPYC/snpcert/pull/55 first