### PR TITLE
fix: Adding DNS compatible with KDS

### DIFF
--- a/modules/network/mkosi.extra/usr/local/lib/systemd/network/wired.network
+++ b/modules/network/mkosi.extra/usr/local/lib/systemd/network/wired.network
@@ -4,3 +4,4 @@ Name=en*
 
 [Network]
 DHCP=yes
+DNS=10.218.15.1


### PR DESCRIPTION
I've found that in the past when I can't fetch content from the KDS, adding this dns address works as a work-around to allow connection. I think we can default network to contain this nameserver to avoid KDS communication issues in different nodes.