### PR TITLE
feat: Add systemd-journal-remote service on the host

### DIFF
--- a/images/host-debian-bookworm/mkosi.conf
+++ b/images/host-debian-bookworm/mkosi.conf
@@ -9,4 +9,4 @@ Distribution=debian
 Release=bookworm
 
 [Content]
-Packages=linux-image-generic,systemd,systemd-boot,resolvconf,locales
+Packages=linux-image-generic,systemd,systemd-boot,resolvconf,locales,systemd-journal-remote

--- a/images/host-fedora-41/mkosi.conf
+++ b/images/host-fedora-41/mkosi.conf
@@ -9,5 +9,5 @@ Distribution=fedora
 Release=41
 
 [Content]
-Packages=kernel,selinux-policy-targeted,systemd,systemd-boot-unsigned,systemd-networkd,systemd-resolved
+Packages=kernel,selinux-policy-targeted,systemd,systemd-boot-unsigned,systemd-networkd,systemd-resolved,systemd-journal-remote
 KernelCommandLine="selinux=0"

--- a/images/host-ubuntu-oracular/mkosi.conf
+++ b/images/host-ubuntu-oracular/mkosi.conf
@@ -11,4 +11,4 @@ Repositories=universe
 
 [Content]
 KernelCommandLine=msr.allow_writes=on
-Packages=linux-image-virtual,systemd,systemd-boot-efi,systemd-resolved,plymouth
+Packages=linux-image-virtual,systemd,systemd-boot-efi,systemd-resolved,plymouth,systemd-journal-remote

--- a/modules/host/mkosi.conf
+++ b/modules/host/mkosi.conf
@@ -1,3 +1,5 @@
 [Include]
 Include=../common
 Include=../network
+Include=../logging/capture-guest-logs-in-host
+

--- a/modules/logging/capture-guest-logs-in-host/README.md
+++ b/modules/logging/capture-guest-logs-in-host/README.md
@@ -1,0 +1,12 @@
+# Host Configuration for logging service
+
+`systemd-journal-remote.service` is configured,enabled and started on the host to receive the guest journal logs over the network using HTTP protocol at log location `/var/log/journal/guest-logs`.
+
+# How to access QEMU guest logs on the host
+
+Make sure to configure, enable and `systemd-journal-upload` service on the guest to receive the real-time guest logs over HTTP protocol at any specific journal log location(for instance, at `/var/log/journal/guest-logs` path).
+
+Guest service logs can be accessed from the host as shown below:
+```sh
+$ journalctl -D /var/log/journal/guest-logs -f -u systemd-userdbd.service
+```

--- a/modules/logging/capture-guest-logs-in-host/mkosi.build
+++ b/modules/logging/capture-guest-logs-in-host/mkosi.build
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eux
+
+# Create guest log directory inside the image root
+mkdir -p "${DESTDIR}/var/log/journal/guest-logs/"
+chown systemd-journal-remote:systemd-journal-remote "${DESTDIR}/var/log/journal/guest-logs/"
+chmod 755 "${DESTDIR}/var/log/journal/guest-logs/"

--- a/modules/logging/capture-guest-logs-in-host/mkosi.extra/usr/lib/systemd/system/systemd-journal-remote.service
+++ b/modules/logging/capture-guest-logs-in-host/mkosi.extra/usr/lib/systemd/system/systemd-journal-remote.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=Journal Remote Sink Service
+Requires=systemd-journal-remote.socket
+
+[Service]
+ExecStart=/usr/lib/systemd/systemd-journal-remote --listen-http=-3 --output=/var/log/journal/guest-logs/
+LockPersonality=yes
+LogsDirectory=journal/guest-logs/
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateNetwork=yes
+PrivateTmp=yes
+ProtectProc=invisible
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+User=systemd-journal-remote
+
+
+# If there are many split up journal files we need a lot of fds to access them
+# all in parallel.
+LimitNOFILE=524288
+
+[Install]
+Also=systemd-journal-remote.socket

--- a/modules/logging/capture-guest-logs-in-host/mkosi.extra/usr/local/lib/systemd/system-preset/10-journal-remote.preset
+++ b/modules/logging/capture-guest-logs-in-host/mkosi.extra/usr/local/lib/systemd/system-preset/10-journal-remote.preset
@@ -1,0 +1,4 @@
+enable systemd-journal-remote.socket
+enable systemd-journal-remote.service
+start systemd-journal-remote.socket
+start systemd-journal-remote.service


### PR DESCRIPTION
Hey Diego, this PR should configure and enables systemd-journal-remote on the host UKI.

Can we once test this artifact on the test node and integrate these changes into your `host-update` branch.