### PR TITLE
Add new guest-opensuse-tumbleweed image

### DIFF
--- a/images/guest-opensuse-tumbleweed/mkosi.conf
+++ b/images/guest-opensuse-tumbleweed/mkosi.conf
@@ -1,0 +1,15 @@
+[Include]
+Include=../../modules/guest
+
+[Distribution]
+Distribution=opensuse
+Release=tumbleweed
+
+[Content]
+Packages=
+	kernel-default
+	systemd
+	systemd-boot
+	systemd-networkd
+	zypper
+	udev


### PR DESCRIPTION
Added OpenSUSE tumbleweed  guest image with minimum package list that supports QEMU boot