### PR TITLE
Feat: Add module to build OVMF from source

### DIFF
--- a/modules/ovmf-build/mkosi.build
+++ b/modules/ovmf-build/mkosi.build
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -eux
+
+OVMF_GIT_URL="https://github.com/tianocore/edk2.git"
+OVMF_BRANCH="edk2-stable202505"
+BUILD_OVMF_PATH="${DESTDIR}/usr/share/build/ovmf/OVMF.fd"
+
+# Clone and access the ovmf repository
+git clone ${OVMF_GIT_URL} --single-branch -b ${OVMF_BRANCH} ovmf
+pushd ovmf >/dev/null
+git submodule update --init --recursive
+
+GCCVERS="GCC5"
+
+BUILD_CMD="nice build -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT=TRUE -n $(getconf _NPROCESSORS_ONLN) ${GCCVERS:+-t $GCCVERS} -a X64 -p OvmfPkg/AmdSev/AmdSevX64.dsc"
+
+
+make -C BaseTools clean
+make -C BaseTools -j "$(getconf _NPROCESSORS_ONLN)"
+set +u
+. ./edksetup.sh --reconfig
+
+touch ./OvmfPkg/AmdSev/Grub/grub.efi
+$BUILD_CMD
+
+mkdir -p "$(dirname "${BUILD_OVMF_PATH}")"
+cp ./Build/AmdSev/DEBUG_GCC5/FV/OVMF.fd "${BUILD_OVMF_PATH}"
+popd >/dev/null

--- a/modules/ovmf-build/mkosi.conf
+++ b/modules/ovmf-build/mkosi.conf
@@ -1,0 +1,3 @@
+[Build]
+WithNetwork=yes
+ToolsTreePackages=iasl,nasm,make,automake,gcc,gcc-c++,mtools,libuuid-devel,python,grub2-efi-x64,grub2-tools,grub2-efi-x64-modules


### PR DESCRIPTION
We have distros that have SEV-SNP compatibility, but the packaged OVMFs do not support SEV-SNP. This build module will build and place a SEV-SNP friendly module in whatever image that includes the module.