### PR TITLE
refactor: change beacon build in mkosi

### DIFF
--- a/modules/beacon/mkosi.build
+++ b/modules/beacon/mkosi.build
@@ -1,17 +1,11 @@
 #!/bin/bash
-set -eux
+set -euo pipefail
+set -x
 
-ls -l "${SRCDIR}"
+# Fetch latest release tag from GitHub API using jq
+LATEST_TAG=$(curl -s https://api.github.com/repos/AMDEPYC/beacon/releases/latest \
+  | jq -r '.tag_name')
 
-BEACON_DIR="${SRCDIR}/beacon"
-
-curl https://sh.rustup.rs -sSf | sh -s -- -y
-source "$HOME/.cargo/env"
-
-rustup target add x86_64-unknown-linux-musl
-
-cargo build  --release --manifest-path "${BEACON_DIR}/Cargo.toml" --target=x86_64-unknown-linux-musl
-
-install -Dm755 \
-  "${BEACON_DIR}/target/x86_64-unknown-linux-musl/release/beacon" \
-  "${DESTDIR}/usr/local/bin/beacon"
+# Download and install into DESTDIR with correct permissions
+curl -fsSL "https://github.com/AMDEPYC/beacon/releases/download/${LATEST_TAG}/beacon-linux-x86_64" \
+  | install -D -m 0755 /dev/stdin "${DESTDIR}/usr/local/bin/beacon"

--- a/modules/beacon/mkosi.conf
+++ b/modules/beacon/mkosi.conf
@@ -1,5 +1,2 @@
 [Build]
 WithNetwork=yes
-ToolsTreePackages=gcc,clang,make,musl-gcc
-BuildSources=../../beacon:beacon
-


### PR DESCRIPTION
Use the release version of beacon of its new repository instead of trying to build it using the internal repository code.