### PR TITLE
Release workflow update

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -109,14 +109,31 @@ jobs:
           elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
           fi
-          # Upload host with custom content-type via uploads API
+
+          # Get the release ID
           RELEASE_ID=$(gh api repos/$GITHUB_REPOSITORY/releases/tags/"${TAG}" --jq .id)
           HOST_FILE="/tmp/release-artifacts/host-${{ matrix.distro }}-${{ matrix.release }}.efi"
+          ASSET_NAME=$(basename "$HOST_FILE")
+
+          # Look for an existing asset with the same name
+          ASSET_ID=$(gh api \
+            repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets \
+            --jq ".[] | select(.name==\"$ASSET_NAME\") | .id")
+
+          # If found, delete it
+          if [ -n "$ASSET_ID" ]; then
+            gh api \
+              --method DELETE \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              repos/$GITHUB_REPOSITORY/releases/assets/$ASSET_ID
+            fi
+
+          # Upload the new asset with the correct Content-Type
           curl --fail -sS -X POST \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Content-Type: application/vnd.dispatch+efi" \
             --data-binary @"$HOST_FILE" \
-            "https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?name=$(basename $HOST_FILE)"
+            "https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?name=$ASSET_NAME"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -23,14 +23,24 @@ jobs:
         run: |
           if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
             TAG="devel"
+            gh release delete "${TAG}" --cleanup-tag --yes || true
+            while git fetch --tags --prune-tags; git tag -l | grep ${TAG}; do
+              sleep 2;
+            done
+            gh release create "${TAG}" \
+              --title "Development Images" \
+              --notes "Automated build of host and guest images from main branch." \
+              --prerelease
           elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
+            gh release delete "${TAG}" --cleanup-tag --yes || true
+            while git fetch --tags --prune-tags; git tag -l | grep ${TAG}; do
+              sleep 2;
+            done
+            gh release create "${TAG}" \
+              --title "SEV Certify ${TAG}" \
+              --notes "OS images for ${TAG} certification"
           fi
-          gh release delete "${TAG}" --cleanup-tag --yes || true
-          gh release create "${TAG}" \
-            --title "Development Images" \
-            --notes "Automated build of host and guest images from main branch." \
-            --prerelease
 
   build:
     name: ${{ matrix.distro }}-${{ matrix.release }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,5 +1,11 @@
 name: build-images
 on:
+  workflow_dispatch:
+    inputs:
+      replace_release:
+        description: 'Replace existing development assets (if any)'
+        required: false
+        type: boolean
   pull_request:
   push:  
     branches: 
@@ -12,7 +18,7 @@ jobs:
   create-release:
     name: create new release for tagged or latest assets
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.replace_release == 'true')
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -21,7 +27,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+          if [[ "${GITHUB_REF}" == "refs/heads/main" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             TAG="devel"
             gh release delete "${TAG}" --cleanup-tag --yes || true
             while git fetch --tags --prune-tags; git tag -l | grep ${TAG}; do
@@ -87,10 +93,10 @@ jobs:
           cp images/host-${{ matrix.distro }}-${{ matrix.release }}/host-${{ matrix.distro }}-${{ matrix.release }}.efi /tmp/release-artifacts/host-${{ matrix.distro }}-${{ matrix.release }}.efi
       
       - name: Upload guest assets (default content type)
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.replace_release == 'true')
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+          if [[ "${GITHUB_REF}" == "refs/heads/main" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             TAG="devel"
           elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
@@ -101,10 +107,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Upload host assets (custom Content-Type)
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.replace_release == 'true')
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+          if [[ "${GITHUB_REF}" == "refs/heads/main" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             TAG="devel"
           elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"


### PR DESCRIPTION
- Fix issue that causes releases to be released as drafts when deleting old ones.
- Allow host images to remove old assets and replace with new ones, in case old builds get placed in what should be new releases.
-  Add the ability to manually run image building, and replace assets if the user so wishes