### PR TITLE
docs: update README with cert table

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -10,7 +10,8 @@ on:
   push:  
     paths-ignore:
       - 'docs/**'
-      - 'README.md'
+      - '**.md'
+      - 'LICENSE'
     branches: 
       - main  
     tags: 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Users/Organizations may target their own SEV-enabled EPYC server for self-servic
 
 ## Certification Result Information
 
-Each certification run automatically creates a GitHub Issue in this repository, documenting the results and assigning a certification level. Issues are tagged by OS and SEV feature to facilitate searching and tracking.
+Each certification run automatically creates a GitHub Issue containing the results and assigning a certification level. Issues are tagged by OS and SEV feature to facilitate searching and tracking.
 
 _Issue tags and details to be added here._
 
 ## Images
 
 
-Host and Guest images are constructed in GitHub Workflows via [`mkosi`](https://github.com/systemd/mkosi). Host images are designed to be booted on a SEV-enabled EPYC server, and are configured with a series of custom systemd services that will run tests on an embedded guest image. The resulting host and guest images are available in GitHub releases in this repository.
+Host and Guest images are constructed in GitHub Workflows via [`mkosi`](https://github.com/systemd/mkosi). Host images are designed to be booted on a SEV-enabled EPYC server, and are configured with a series of tests in the form of custom systemd services that will run on an embedded guest image. The resulting host and guest images are available in GitHub releases.
 
 

--- a/docs/how-to-run-guest-manually.md
+++ b/docs/how-to-run-guest-manually.md
@@ -1,4 +1,4 @@
-The typical way to run tests are fully automated. However if you're developing tests or isolating an issue, you may find it useful to run guests manually. The following instructions assume you are running on AMD EPYC hardware that has been fully enabled for SEV.
+The typical way to run tests is fully automated, including running guests automatically. However if you're developing tests or isolating an issue, you may find it useful to run guests manually. The following instructions assume you are running on AMD EPYC hardware that has been fully enabled for SEV.
 
 # Prerequisites
 
@@ -43,7 +43,7 @@ $ qemu-system-x86_64 \
   -kernel ${EFI_PATH}
 ```
 
-- `EFI_PATH`: 
+- `$EFI_PATH`: 
   - If you're running inside a host image from this repository, the guest image is embedded at: `/usr/local/lib/guest-image/guest.efi`.
   - Otherwise, set this to the path of the guest image downloaded/built in step 1.
 


### PR DESCRIPTION
See changes on the fork branch here: https://github.com/amd-aliem/sev-certify/tree/readme-update

This change:
- moves existing README contents into `docs/how-to-run-guest-manually.md`
- adds a cert table to README, along with sections of general information about the project.