### PR TITLE
Clean up SEV title in the SEV certificate.

### DIFF
--- a/modules/beacon/mkosi.extra/usr/local/lib/scripts/beacon-report.sh
+++ b/modules/beacon/mkosi.extra/usr/local/lib/scripts/beacon-report.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/bash
 set -euo pipefail
 
-CERT_FILE="${HOME:-/root}/sev_certificate.txt"
+SEV_VERSIONS=("3.0-0")
+SEV_CERT_FILE=""
 
 # Determine OS name and version
 if [ -f /etc/os-release ]; then
@@ -15,17 +16,20 @@ else
     OS_LABEL="${OS_NAME}"
 fi
 
-# Get current date
-TODAY=$(date +%Y-%m-%d)
+# Loop over to generate beacon report for all SEV certificates
+for sev_version in "${SEV_VERSIONS[@]}"; do
+  # Build title
+  if [ -n "$OS_VERSION" ]; then
+    SEV_TITLE="${OS_NAME} ${OS_VERSION} SEV version ${sev_version}"
+  else
+    SEV_TITLE="${OS_NAME} SEV version ${sev_version}"
+  fi
 
-# Build title
-if [ -n "$OS_VERSION" ]; then
-    TITLE="${OS_NAME} ${OS_VERSION} ${TODAY} SEV Certificate"
-else
-    TITLE="${OS_NAME} ${TODAY} SEV Certificate"
-fi
+  # Obtain SEV Version Content
+  SEV_CERT_FILE="${HOME:-/root}/sev_certificate_v${sev_version}.txt"
 
-# Call beacon
-beacon report --title "$TITLE" --body "$CERT_FILE" --label "certificate" --label "${OS_LABEL}"
+  # Call beacon
+  beacon report --title "$SEV_TITLE" --body "$SEV_CERT_FILE" --label "certificate" --label "${OS_LABEL}"
 
-echo "Published SEV certificate via beacon with title: $TITLE"
+  echo "Published SEV certificate via beacon with title: $SEV_TITLE"
+done

--- a/modules/logging/sev-certificate-generator/mkosi.extra/usr/local/lib/scripts/generate_sev_certificate/sev_certificate/generate_sev_certificate.py
+++ b/modules/logging/sev-certificate-generator/mkosi.extra/usr/local/lib/scripts/generate_sev_certificate/sev_certificate/generate_sev_certificate.py
@@ -19,5 +19,5 @@ sev_report += sev_report_v_3_0_0.generate_sev_certificate()
 print(sev_report)
 
 # Write certificate to file
-sev_report_v_3_0_0.write_sev_certificate(sev_report, "~/sev_certificate.txt")
+sev_report_v_3_0_0.write_sev_certificate(sev_report, "~/sev_certificate_v3.0-0.txt")
 


### PR DESCRIPTION
- Removed dates and SEV Certificate from the title.
- Added SEV version in the title.
- Refactored SEV Certificate file name to sev_certificate_v3.0-0.txt.
- Added SEV Version loop in `beacon-report.sh` to generate beacon report for all SEV versions.

Please take a look at the [issues of my forked repo](https://github.com/LakshmiSaiHarika/snpcert/issues) for the updated results of this PR.