### PR TITLE
build: support forked beacon repos

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -6,6 +6,10 @@ on:
         description: 'Replace existing development assets (if any)'
         required: false
         type: boolean
+      beacon_owner:
+        description: 'Beacon Repo Owner (optional)'
+        required: false
+        type: string
   pull_request:
   push:  
     paths-ignore:
@@ -79,6 +83,11 @@ jobs:
           sudo sed -i 's/noble/plucky/g' /etc/apt/sources.list.d/ubuntu.sources || true
           sudo apt update
           sudo apt install -y mkosi
+
+      - name: Set dynamic mkosi vars
+        if: github.event.inputs.beacon_owner != ''
+        run: |
+          sed -i "/^\[Build\]/a\Environment=BEACON_OWNER=${{ github.event.inputs.beacon_owner }}" modules/beacon/mkosi.conf
 
       - name: Build guest-${{ matrix.distro }}-${{ matrix.release }}
         run: |

--- a/modules/beacon/mkosi.build
+++ b/modules/beacon/mkosi.build
@@ -2,10 +2,12 @@
 set -euo pipefail
 set -x
 
+BEACON_OWNER="${BEACON_OWNER:-AMDEPYC}"
+
 # Fetch latest release tag from GitHub API using jq
-LATEST_TAG=$(curl -s https://api.github.com/repos/AMDEPYC/beacon/releases/latest \
+LATEST_TAG=$(curl -s https://api.github.com/repos/${BEACON_OWNER}/beacon/releases/latest \
   | jq -r '.tag_name')
 
 # Download and install into DESTDIR with correct permissions
-curl -fsSL "https://github.com/AMDEPYC/beacon/releases/download/${LATEST_TAG}/beacon-linux-x86_64" \
+curl -fsSL "https://github.com/${BEACON_OWNER}/beacon/releases/download/${LATEST_TAG}/beacon-linux-x86_64" \
   | install -D -m 0755 /dev/stdin "${DESTDIR}/usr/local/bin/beacon"


### PR DESCRIPTION
Add option to specify a forked beacon repo. This will incorporate the latest release of that forked repo, instead of the default AMDEPYC one.

<img width="320" height="292" alt="image" src="https://github.com/user-attachments/assets/79c6d667-b27e-48c3-a304-cccf5d40f73d" />

