### PR TITLE
fix: only attach milestone if release build

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -80,6 +80,11 @@ jobs:
           sudo apt update
           sudo apt install -y mkosi
 
+      - name: Set dynamic mkosi vars
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          sed -i "/^\[Service\]/a\Environment=\"SET_MILESTONE=true\"" modules/beacon/mkosi.extra/usr/local/lib/systemd/system/beacon-report.service
+
       - name: Build guest-${{ matrix.distro }}-${{ matrix.release }}
         run: |
           sudo mkosi --image-id=guest-${{ matrix.distro }}-${{ matrix.release }} -C images/guest-${{ matrix.distro }}-${{ matrix.release }}/ cat-config

--- a/modules/beacon/mkosi.extra/usr/local/lib/scripts/beacon-report.sh
+++ b/modules/beacon/mkosi.extra/usr/local/lib/scripts/beacon-report.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SEV_VERSIONS=("3.0-0")
 SEV_CERT_FILE=""
+SET_MILESTONE="${SET_MILESTONE:-false}"
 
 # Determine OS name and version
 if [ -f /etc/os-release ]; then
@@ -29,11 +30,11 @@ for sev_version in "${SEV_VERSIONS[@]}"; do
   SEV_CERT_FILE="${HOME:-/root}/sev_certificate_v${sev_version}.txt"
 
   # Call beacon
-  if [ -e "${SEV_CERT_FILE}" ] && [ -z "$(grep "❌" "${SEV_CERT_FILE}")" ]; then
-    # Add milestone if no errors encountered
-    beacon report --title "$SEV_TITLE" --body "$SEV_CERT_FILE" --label "certificate" --label "${OS_LABEL}" --milestone "v${sev_version}"
+  if [ -e "${SEV_CERT_FILE}" ] && [ -z "$(grep "❌" "${SEV_CERT_FILE}")" ] && [ "${SET_MILESTONE}" == "true" ]; then
+    # Add milestone if no errors encountered and if this is a release build.
+    beacon report --title "$SEV_TITLE" --body "$SEV_CERT_FILE" --label "certificate" --label "os-${OS_LABEL}" --milestone "v${sev_version}"
   else
-    beacon report --title "$SEV_TITLE" --body "$SEV_CERT_FILE" --label "certificate" --label "${OS_LABEL}"
+    beacon report --title "$SEV_TITLE" --body "$SEV_CERT_FILE" --label "certificate" --label "os-${OS_LABEL}"
   fi
 
   echo "Published SEV certificate via beacon with title: $SEV_TITLE"


### PR DESCRIPTION
We don't want images built under `devel` to attach milestones - only the images built for new releases.