### PR TITLE
Beacon report fix for debian forky release

### DIFF
--- a/modules/beacon/mkosi.extra/usr/local/lib/scripts/beacon-report.sh
+++ b/modules/beacon/mkosi.extra/usr/local/lib/scripts/beacon-report.sh
@@ -9,7 +9,13 @@ SET_MILESTONE="${SET_MILESTONE:-false}"
 if [ -f /etc/os-release ]; then
     . /etc/os-release
     OS_NAME="${ID}"            
-    OS_VERSION="${VERSION_ID}" 
+    OS_VERSION="${VERSION_ID:-""}"
+
+    # Initialize OS release with the OS VERSION_CODENAME if VERSION_ID is missing in /etc/os-release.
+    if [[ -z "${OS_VERSION}" && -n "${VERSION_CODENAME}" ]]; then
+        OS_VERSION="${VERSION_CODENAME}"
+    fi
+
     OS_LABEL="${OS_NAME}-${OS_VERSION}"
 else
     OS_NAME="$(uname -s)"


### PR DESCRIPTION
- This pull request resolves the beacon report issue caused by the absence of the VERSION_ID field in the /etc/os-release file on Debian forky distribution.
- Additionally, this pull request introduces a pre-release tag for any development-stage Linux distribution that lacks a VERSION_ID in its /etc/os-release file.

<img width="524" height="211" alt="image" src="https://github.com/user-attachments/assets/4fa41844-2999-4c87-a361-96006e9ceeda" />

Debian Forky SNP certification GH Issue link: [here](https://github.com/LakshmiSaiHarika/snpcert/issues/38)