### PR TITLE
New OpenSUSE OS: Add OpenSUSE Tumbleweed OS to verify SNP certification.

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo sed -i 's/noble/plucky/g' /etc/apt/sources.list.d/ubuntu.sources || true
+          sudo sed -i 's/noble/resolute/g' /etc/apt/sources.list.d/ubuntu.sources || true
           sudo apt update
           sudo apt install -y mkosi
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -79,6 +79,8 @@ jobs:
             release: "25.10"
           - distro: ubuntu
             release: "26.04"
+          - distro: opensuse
+            release: "16.0"
 
     steps:
       - name: Checkout

--- a/images/guest-opensuse-16.0/mkosi.conf
+++ b/images/guest-opensuse-16.0/mkosi.conf
@@ -1,0 +1,28 @@
+[Include]
+Include=../../modules/build/guest
+
+[Distribution]
+Distribution=opensuse
+Release=16.0
+RepositoryKeyFetch=yes
+
+[Content]
+Packages=
+        kernel-default
+        systemd
+        systemd-boot
+        systemd-networkd
+        systemd-resolved
+        systemd-journal-remote
+        zypper
+        udev
+        iputils
+        ca-certificates
+        p11-kit-tools
+        jq
+        patterns-devel-base-devel_basis
+        bind-utils
+        xxd
+
+[Build]
+Environment=VERSION="16.0"

--- a/images/host-opensuse-16.0/mkosi.conf
+++ b/images/host-opensuse-16.0/mkosi.conf
@@ -27,7 +27,6 @@ Packages=
         systemd
         systemd-boot
         systemd-resolved
-        qemu-ovmf-x86_64
         qemu
         rpm
         systemd-journal-remote
@@ -37,7 +36,13 @@ Packages=
         python3-emoji
         jq
         avahi
+	vim
+	openssh-clients
+	openssh
+	openssh-server
+	NetworkManager
 KernelCommandLine="iommu=nopt"
 
 [Build]
 Environment=VERSION="16.0"
+SandboxTrees=mkosi.pkgmngr

--- a/images/host-opensuse-16.0/mkosi.conf
+++ b/images/host-opensuse-16.0/mkosi.conf
@@ -1,0 +1,43 @@
+[Include]
+Include=../../modules/build/host
+
+[Distribution]
+Distribution=opensuse
+Release=16.0
+RepositoryKeyFetch=yes
+
+[Content]
+Packages=
+        kernel-default
+        systemd
+        systemd-boot
+        systemd-networkd
+        systemd-resolved
+        zypper
+        ca-certificates
+        p11-kit-tools
+        jq
+        patterns-devel-base-devel_basis
+        NetworkManager
+        systemd-networkd
+        SUSEConnect
+        shadow
+        qemu
+        kernel
+        systemd
+        systemd-boot
+        systemd-resolved
+        qemu-ovmf-x86_64
+        qemu
+        rpm
+        systemd-journal-remote
+        xxd
+        python3
+        python3-pip
+        python3-emoji
+        jq
+        avahi
+KernelCommandLine="iommu=nopt"
+
+[Build]
+Environment=VERSION="16.0"

--- a/images/host-opensuse-16.0/mkosi.pkgmngr/etc/zypp/repos.d/virtualization.repo
+++ b/images/host-opensuse-16.0/mkosi.pkgmngr/etc/zypp/repos.d/virtualization.repo
@@ -1,0 +1,8 @@
+[Virtualization]
+name=Virtualization (16.0)
+enabled=1
+autorefresh=1
+baseurl=https://download.opensuse.org/repositories/Virtualization/16.0/
+gpgcheck=1
+gpgkey=https://download.opensuse.org/repositories/Virtualization/16.0/repodata/repomd.xml.key
+priority=90

--- a/images/host-opensuse-16.0/mkosi.pkgmngr/etc/zypp/zypp.conf
+++ b/images/host-opensuse-16.0/mkosi.pkgmngr/etc/zypp/zypp.conf
@@ -1,0 +1,2 @@
+[main]
+solver.allowVendorChange = true

--- a/images/host-opensuse-16.0/mkosi.prepare
+++ b/images/host-opensuse-16.0/mkosi.prepare
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "$1" == "final" ]]; then
+    zypper --non-interactive --gpg-auto-import-keys refresh Virtualization
+    zypper --non-interactive install --allow-vendor-change --from Virtualization qemu-ovmf-x86_64
+fi

--- a/modules/build/common/load-kernel-modules/mkosi.build
+++ b/modules/build/common/load-kernel-modules/mkosi.build
@@ -4,7 +4,7 @@ set -eux
 os_name=$(grep '^ID=' /buildroot/etc/os-release | cut -d'=' -f2 | tr -d '"')
 
 case "$os_name" in
-  debian|ubuntu|centos)
+  debian|ubuntu|centos|opensuse-leap)
     echo "Applying module configuration for $os_name"
     ;;
   *)

--- a/modules/build/common/mkosi.conf
+++ b/modules/build/common/mkosi.conf
@@ -1,6 +1,6 @@
 [Build]
 ToolsTreeDistribution=fedora
-ToolsTreeRelease=42
+ToolsTreeRelease=44
 ToolsTree=default
 
 [Output]
@@ -21,4 +21,5 @@ Include=./snpguest
 Include=./network
 Include=./network-fix
 Include=./load-kernel-modules
+Include=./systemd-conf
 

--- a/modules/build/common/network-fix/mkosi.build
+++ b/modules/build/common/network-fix/mkosi.build
@@ -6,7 +6,7 @@ resolv_conf_link="https://raw.githubusercontent.com/systemd/systemd/refs/heads/m
 os_name=$(grep '^ID=' /buildroot/etc/os-release | cut -d'=' -f2 | tr -d '"')
 
 case "$os_name" in
-  rocky|centos)
+  rocky|centos|opensuse-leap)
     ;;
   *)
     echo "Skipping resolv.conf update for $os_name"

--- a/modules/build/common/systemd-conf/mkosi.extra/usr/lib/systemd/system.conf.d/10-status-format.conf
+++ b/modules/build/common/systemd-conf/mkosi.extra/usr/lib/systemd/system.conf.d/10-status-format.conf
@@ -1,0 +1,2 @@
+[Manager]
+StatusUnitFormat=combined

--- a/modules/launch/host/guest-measurement/mkosi.extra/usr/local/lib/scripts/guest_measurement.sh
+++ b/modules/launch/host/guest-measurement/mkosi.extra/usr/local/lib/scripts/guest_measurement.sh
@@ -7,7 +7,7 @@ MEASUREMENT_FILE="/usr/local/lib/guest-image/guest_measurement.txt"
 
 # Check which OVMF binary to use
 OVMF_PATH=""
-for path in /usr/share/ovmf/OVMF.amdsev.fd /usr/share/edk2/ovmf/OVMF.amdsev.fd; do
+for path in /usr/share/ovmf/OVMF.amdsev.fd /usr/share/edk2/ovmf/OVMF.amdsev.fd /usr/share/qemu/ovmf-x86_64-sev.bin; do
   if [ -f "$path" ]; then
     OVMF_PATH="$path"
     break

--- a/modules/launch/host/launch-guest/mkosi.extra/usr/local/lib/scripts/launch-guest.sh
+++ b/modules/launch/host/launch-guest/mkosi.extra/usr/local/lib/scripts/launch-guest.sh
@@ -8,7 +8,7 @@ GUEST_ERROR_LOG="/tmp/guest-error.log"
 
 # Check which OVMF binary to use
 OVMF_PATH=""
-for path in /usr/share/ovmf/OVMF.amdsev.fd /usr/share/edk2/ovmf/OVMF.amdsev.fd; do
+for path in /usr/share/ovmf/OVMF.amdsev.fd /usr/share/edk2/ovmf/OVMF.amdsev.fd /usr/share/qemu/ovmf-x86_64-sev.bin; do
   if [ -f "${path}" ]; then
     OVMF_PATH="${path}"
     break

--- a/modules/report/host/report-done/mkosi.extra/usr/local/lib/systemd/system/report-done.service
+++ b/modules/report/host/report-done/mkosi.extra/usr/local/lib/systemd/system/report-done.service
@@ -2,8 +2,8 @@
 Description=Barrier that triggers report services
 DefaultDependencies=no
 
-Requires=display-guest-logs.service sev-certificate-generator.service
-After=display-guest-logs.service sev-certificate-generator.service
+Requires=sev-certificate-generator.service
+After=sev-certificate-generator.service
 
 [Service]
 Type=oneshot

--- a/modules/report/host/sev-certificate-generator/mkosi.extra/usr/local/lib/scripts/generate_sev_certificate/test_environment/sev_version_3_0_0_0/host_environment/host_os_package.py
+++ b/modules/report/host/sev-certificate-generator/mkosi.extra/usr/local/lib/scripts/generate_sev_certificate/test_environment/sev_version_3_0_0_0/host_environment/host_os_package.py
@@ -11,6 +11,7 @@ class HostOSPackage:
     qemu["debian"]="qemu-system"
     qemu["centos"]="qemu-kvm-core"
     qemu["rocky"]="qemu-kvm-core"
+    qemu["opensuse-leap"]="qemu"
 
     ovmf={}
     ovmf["fedora"]="edk2-ovmf"
@@ -18,4 +19,5 @@ class HostOSPackage:
     ovmf["debian"]="ovmf"
     ovmf["centos"]="edk2-ovmf"
     ovmf["rocky"]="edk2-ovmf"
+    ovmf["opensuse-leap"]="qemu-ovmf-x86_64"
 

--- a/modules/report/host/sev-certificate-generator/mkosi.extra/usr/local/lib/scripts/generate_sev_certificate/test_environment/sev_version_3_0_0_0/host_environment/package_version.sh
+++ b/modules/report/host/sev-certificate-generator/mkosi.extra/usr/local/lib/scripts/generate_sev_certificate/test_environment/sev_version_3_0_0_0/host_environment/package_version.sh
@@ -13,7 +13,7 @@ fi
 package="$1"
 
 declare -A package_managers
-package_managers=( ["fedora"]="rpm" ["ubuntu"]="apt" ["debian"]="apt" ["centos"]="rpm" ["rocky"]="rpm" )
+package_managers=( ["fedora"]="rpm" ["ubuntu"]="apt" ["debian"]="apt" ["centos"]="rpm" ["rocky"]="rpm" ["opensuse-leap"]="zypper")
 
 os_name=$(grep '^ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"')
 os_package_manager=${package_managers[${os_name}]}
@@ -25,6 +25,10 @@ case "$os_package_manager" in
     ;;
   rpm)
     package_version=$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' ${package} 2>/dev/null || echo "" )
+    echo -e "${package_version}"
+    ;;
+  zypper)
+    package_version=$(zypper info package ${package} 2>/dev/null | awk '/Version/ {print $3}' || echo "")
     echo -e "${package_version}"
     ;;
   *)


### PR DESCRIPTION
- Added OpenSuse Tumbleweed distribution to verify SNP certification process on this Opensuse distribution.
- For the results, please take a look at my forked GH issue for the OpenSUSE Tumbleweed release  [here](https://github.com/LakshmiSaiHarika/snpcert/issues/40)