### PR TITLE
Wait for network connectivity before running SEV attestation

### DIFF
--- a/modules/snpguest/mkosi.extra/usr/local/lib/systemd/system/snpguest-attestation.service
+++ b/modules/snpguest/mkosi.extra/usr/local/lib/systemd/system/snpguest-attestation.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Run SNP Regular Attestation after boot
 DefaultDependencies=no
-After=snpguest-ok.service
-Wants=snpguest-ok.service
+After=snpguest-ok.service network-online.target
+Wants=snpguest-ok.service network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
- Modified snpguest-attestation.service to depend on network-online.target
- This ensures the attestation service waits for network connectivity before attempting to contact AMD Key Distribution Server
- Prevents early failures due to network not being ready