### PR TITLE
ci: add permissions options to build-and-release workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -17,6 +17,10 @@ on:
     tags: 
       - 'v*'
 
+permissions:
+  contents: write  # Required for creating releases and uploading assets
+  actions: read    # Required for workflow access
+
 jobs:
   # Development release for tag or main pushes
   create-release:


### PR DESCRIPTION
- Add contents: write permission for creating releases
- Add actions: read permission for workflow access
- Fixes HTTP 403 error when creating releases due to repository/org restrictions, it prevented the build actions from completing due to access issues