### PR TITLE
fix: remove hardcoded DNS server from wired network config

### DIFF
--- a/modules/common/mkosi.extra/usr/local/lib/systemd/network/wired.network
+++ b/modules/common/mkosi.extra/usr/local/lib/systemd/network/wired.network
@@ -4,4 +4,3 @@ Name=en*
 
 [Network]
 DHCP=yes
-DNS=10.218.15.1


### PR DESCRIPTION
- Remove hardcoded DNS=10.218.15.1 from systemd network configuration to allow DHCP-provided DNS servers to be used instead. This makes the configuration more portable across different network environments
- It was observed that having this DNS configured would cause DNS failures inside the Guest VM when it ran it's attestation tests on a network environment outside of AMD's Network