### PR TITLE
feat: adding support for ubuntu 25.10

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -75,6 +75,8 @@ jobs:
             release: 10
           - distro: debian
             release: forky
+          - distro: ubuntu
+            release: "25.10"
 
     steps:
       - name: Checkout

--- a/images/guest-ubuntu-25.10/mkosi.conf
+++ b/images/guest-ubuntu-25.10/mkosi.conf
@@ -1,0 +1,27 @@
+[Include]
+Include=../../modules/load-kernel-modules
+Include=../../modules/guest
+
+[Distribution]
+Distribution=ubuntu
+Release=questing
+Repositories=universe
+
+[Content]
+Packages=
+	linux-image-6.17.0-8-generic
+    linux-modules-6.17.0-8-generic
+	systemd
+	systemd-boot-efi
+	systemd-resolved
+	plymouth
+    login.defs
+	login
+    systemd-journal-remote
+    openssl
+    ca-certificates
+    jq
+	xxd
+
+[Build]
+Environment=VERSION="25.10"

--- a/images/host-ubuntu-25.10/mkosi.conf
+++ b/images/host-ubuntu-25.10/mkosi.conf
@@ -1,0 +1,36 @@
+[Include]
+#Load Kernel modules
+Include=../../modules/load-kernel-modules
+# Host Components
+Include=../../modules/host
+
+[Distribution]
+Distribution=ubuntu
+Release=questing
+Repositories=universe
+RepositoryKeyFetch=yes
+
+[Content]
+Packages=
+	linux-image-6.17.0-8-generic
+	systemd
+	systemd-boot-efi
+	systemd-resolved
+	plymouth
+	login.defs
+	login
+	systemd-journal-remote
+	qemu-system
+	apt
+	ovmf
+	xxd
+	python3
+	python3-pip
+	python3-emoji
+	jq
+	apt
+	avahi-daemon
+
+
+[Build]
+Environment=VERSION="25.10"


### PR DESCRIPTION
Adding the mkosi files and workflow changes needed to add ubuntu 25.10 to the repo.

Succesful run can be found here: https://github.com/DGonzalezVillal/sev-certify/issues/58