### PR TITLE
fix: build tag rate limit issues

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -88,6 +88,22 @@ jobs:
           sudo apt update
           sudo apt install -y mkosi
 
+      - name: Fetch latest release tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          
+          # Fetch latest tags using gh CLI (automatically authenticated)
+          SNPGUEST_TAG=$(gh release view --repo virtee/snpguest --json tagName --jq '.tagName')
+          BEACON_TAG=$(gh release view --repo AMDEPYC/beacon --json tagName --jq '.tagName')
+          SNPHOST_TAG=$(gh release view --repo virtee/snphost --json tagName --jq '.tagName')
+          
+          # Inject environment variables into mkosi.conf files
+          sed -i "/^\[Build\]/a\Environment=SNPGUEST_TAG=$SNPGUEST_TAG" modules/snpguest-build/mkosi.conf
+          sed -i "/^\[Build\]/a\Environment=BEACON_TAG=$BEACON_TAG" modules/beacon/mkosi.conf
+          sed -i "/^\[Build\]/a\Environment=SNPHOST_TAG=$SNPHOST_TAG" modules/snphost/mkosi.conf
+
       - name: Build guest-${{ matrix.distro }}-${{ matrix.release }}
         run: |
           sudo mkosi --image-id=guest-${{ matrix.distro }}-${{ matrix.release }} -C images/guest-${{ matrix.distro }}-${{ matrix.release }}/ cat-config
@@ -156,4 +172,3 @@ jobs:
             "https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?name=$ASSET_NAME"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          

--- a/modules/beacon/mkosi.build
+++ b/modules/beacon/mkosi.build
@@ -2,9 +2,8 @@
 set -euo pipefail
 set -x
 
-# Fetch latest release tag from GitHub API using jq
-LATEST_TAG=$(curl -s https://api.github.com/repos/AMDEPYC/beacon/releases/latest \
-  | jq -r '.tag_name')
+# Use BEACON_TAG if set, otherwise fetch from GitHub API
+LATEST_TAG="${BEACON_TAG:-$(curl -s https://api.github.com/repos/AMDEPYC/beacon/releases/latest | jq -r '.tag_name')}"
 
 # Download and install into DESTDIR with correct permissions
 curl -fsSL "https://github.com/AMDEPYC/beacon/releases/download/${LATEST_TAG}/beacon-linux-x86_64" \

--- a/modules/snpguest-build/mkosi.build
+++ b/modules/snpguest-build/mkosi.build
@@ -2,9 +2,8 @@
 set -euo pipefail
 set -x
 
-# Fetch latest release tag from GitHub API
-LATEST_TAG=$(curl -s https://api.github.com/repos/virtee/snpguest/releases/latest \
-  | jq -r '.tag_name')
+# Use SNPGUEST_TAG if set, otherwise fetch from GitHub API
+LATEST_TAG="${SNPGUEST_TAG:-$(curl -s https://api.github.com/repos/virtee/snpguest/releases/latest | jq -r '.tag_name')}"
 
 # Download and install into DESTDIR with correct permissions
 curl -fsSL "https://github.com/virtee/snpguest/releases/download/${LATEST_TAG}/snpguest" \

--- a/modules/snphost/mkosi.build
+++ b/modules/snphost/mkosi.build
@@ -2,9 +2,8 @@
 set -euo pipefail
 set -x
 
-# Fetch latest release tag from GitHub API
-LATEST_TAG=$(curl -s https://api.github.com/repos/virtee/snphost/releases/latest \
-  | jq -r '.tag_name')
+# Use SNPHOST_TAG if set, otherwise fetch from GitHub API
+LATEST_TAG="${SNPHOST_TAG:-$(curl -s https://api.github.com/repos/virtee/snphost/releases/latest | jq -r '.tag_name')}"
 
 # Download and install into DESTDIR with correct permissions
 curl -fsSL "https://github.com/virtee/snphost/releases/download/${LATEST_TAG}/snphost" \


### PR DESCRIPTION
The build-images GH action is sometimes failing to fetch repo latest tags. Adding some debug prints showed it was getting rate limited. GH rate limits by IP for unauthenticated requests. Fix by using GH token to fetch the tag.

I did not want to pass the token itself as it seems insecure, so passing tag payload mkosi variable. Alternate solution could be to introduce some waits, but according to API unauthenticated requests are 60/hour... https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28

Not sure why downloading the release assets doesn't appear to be hitting this limit, but in the meantime I've run the entire build 3 times and haven't seen failures so far.