### PR TITLE
For Ubuntu 25.04 Fix, Kernel Version is changed from 6.14.0-29 to 6.14.0-37

### DIFF
--- a/images/guest-ubuntu-25.04/mkosi.conf
+++ b/images/guest-ubuntu-25.04/mkosi.conf
@@ -9,8 +9,8 @@ Repositories=universe
 
 [Content]
 Packages=
-	linux-image-6.14.0-29-generic
-	linux-modules-extra-6.14.0-29-generic
+	linux-image-6.14.0-37-generic
+	linux-modules-extra-6.14.0-37-generic
 	systemd
 	systemd-boot-efi
 	systemd-resolved

--- a/images/host-ubuntu-25.04/mkosi.conf
+++ b/images/host-ubuntu-25.04/mkosi.conf
@@ -12,7 +12,7 @@ RepositoryKeyFetch=yes
 
 [Content]
 Packages=
-	linux-image-6.14.0-29-generic
+	linux-image-6.14.0-37-generic
 	systemd
 	systemd-boot-efi
 	systemd-resolved


### PR DESCRIPTION
To fix mkosi build issue for Ubuntu 25.04 OS, I changed the current kernel version from 6.14.0-29 to 6.14.0-37 as linux-kernel-6.14.0-29 package got removed as per the canonical link ([here](https://code.launchpad.net/ubuntu/plucky/amd64/linux-image-6.14.0-29-generic))