### PR TITLE
Add Ubuntu 26.04 support into sev-certify

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -77,6 +77,8 @@ jobs:
             release: forky
           - distro: ubuntu
             release: "25.10"
+          - distro: ubuntu
+            release: "26.04"
 
     steps:
       - name: Checkout

--- a/images/guest-ubuntu-26.04/mkosi.conf
+++ b/images/guest-ubuntu-26.04/mkosi.conf
@@ -1,0 +1,50 @@
+[Include]
+Include=../../modules/build/guest
+
+[Distribution]
+Distribution=ubuntu
+Release=resolute
+Repositories=main,universe
+RepositoryKeyFetch=yes
+
+[Content]
+Packages=
+	linux-image-generic
+	linux-modules-*-generic
+	linux-modules-extra-*
+	systemd
+	systemd-boot-efi
+	systemd-resolved
+	network-manager
+	plymouth
+	login.defs
+	login
+	systemd-journal-remote
+	openssl
+	ca-certificates
+	jq
+	xxd
+
+# Remove all guest kernel modules to optimize the guest image size
+KernelModulesExclude=.*
+
+# Add required guest kernel modules
+KernelModulesInclude=
+	msr
+	sev-guest
+
+	# Core networking support on the guest
+	net/core/
+	net/ipv4/
+	net/ipv6/
+	net/packet/
+	net/netfilter/
+
+	# virtio-net-pci related  network modules
+	drivers/net/virtio_net.ko
+	drivers/virtio/virtio.ko
+	drivers/virtio/virtio_ring.ko
+	drivers/virtio/virtio_pci.ko
+
+[Build]
+Environment=VERSION="26.04"

--- a/images/host-ubuntu-26.04/mkosi.conf
+++ b/images/host-ubuntu-26.04/mkosi.conf
@@ -1,0 +1,178 @@
+[Include]
+Include=../../modules/build/host
+
+[Distribution]
+Distribution=ubuntu
+Release=resolute
+Repositories=main,universe
+RepositoryKeyFetch=yes
+
+[Content]
+Packages=
+	linux-modules-*-generic
+	linux-image-generic
+	linux-modules-extra-*
+	systemd
+	systemd-boot-efi
+	systemd-resolved
+	network-manager
+	login.defs
+	login
+	systemd-journal-remote
+	qemu-system
+	apt
+	ovmf
+	xxd
+	python3
+	python3-dev
+	python3-pip
+	python3-emoji
+	jq
+	apt
+	avahi-daemon
+	g++
+	g++-x86-64-linux-gnu
+
+# Remove some of the host kernel modules to bring Ubuntu 26.04 host image size under 1G
+KernelModulesExclude=
+	# GPU drivers
+	nvidia.*
+	amdgpu
+	i915
+	radeon
+	nouveau
+	drivers/gpu/
+
+	# Bluetooth
+	net/bluetooth
+	drivers/bluetooth/
+
+	# Wireless networking
+	net/wireless/
+	drivers/net/wireless/
+	net/mac80211/
+
+	# Alternative filesystems - ext4 is sufficient
+	reiserfs
+	gfs2
+	ocfs2
+	jfs
+	f2fs
+	ntfs
+	hfs
+	udf
+
+	# Audio - not needed for headless VM host
+	sound/
+
+	# Media devices (cameras, TV tuners, etc.) - not needed
+	drivers/media/
+
+	# Staging drivers - experimental/unmaintained code
+	drivers/staging/
+
+	# Amateur radio
+	drivers/net/hamradio/
+
+	# ISDN telephony - obsolete technology
+	drivers/isdn/
+
+	# Near Field Communication
+	drivers/nfc/
+	net/nfc/
+
+	# WiMAX - obsolete wireless technology
+	drivers/net/wimax/
+
+	# Telephony
+	drivers/telephony/
+
+	# IrDA - obsolete infrared technology
+	#net/irda/
+
+	# ATM networking
+	net/atm/
+
+	# 6LoWPAN - IoT protocol
+	net/6lowpan/
+
+	#Advanced  network protocols
+	net/ax25/
+	net/can/
+	net/decnet/
+	net/x25/
+	net/lapb/
+	net/rose/
+	net/netrom/
+	net/appletalk/
+	net/ipx/
+	net/phonet/
+	net/ieee802154/
+	net/caif/
+	net/tipc/
+	net/rds/
+
+	# InfiniBand/RDMA - high-performance networking not needed
+	drivers/infiniband/
+
+	# USB peripheral devices - keep core USB but remove peripherals
+	drivers/usb/misc/
+	drivers/usb/serial/
+	drivers/usb/image/
+	drivers/usb/atm/
+	drivers/usb/gadget/
+
+	# Input devices - keyboards, mice, touchscreens, joysticks
+	drivers/input/joystick/
+	drivers/input/tablet/
+	drivers/input/touchscreen/
+	drivers/input/misc/
+
+	# Industrial I/O - sensors and ADCs
+	drivers/iio/
+
+	# LED drivers
+	drivers/leds/
+
+	# Memory Technology Devices - flash storage
+	drivers/mtd/
+
+	# Multi-Function Devices
+	drivers/mfd/
+
+	# Greybus - modular phone hardware
+	drivers/greybus/
+
+	# Hardware crypto accelerators - use software crypto
+	drivers/crypto/
+
+	# FPGA drivers
+	drivers/fpga/
+
+	# Remote processors
+	drivers/remoteproc/
+
+	# SPI devices
+	drivers/spi/
+
+	# I2C devices (some may be needed, but most peripherals are not)
+	drivers/i2c/busses/
+
+	# Watchdog timers - most hardware-specific ones not needed
+	drivers/watchdog/
+
+	# Floppy and legacy storage
+	drivers/block/floppy.ko
+	drivers/block/paride/
+
+	# Gameport
+	drivers/input/gameport/
+
+	# Accessibility drivers
+	drivers/accessibility/
+
+	# Android drivers
+	drivers/android/
+
+[Build]
+Environment=VERSION="26.04"

--- a/modules/launch/host/launch-guest/mkosi.extra/usr/local/lib/scripts/launch-guest.sh
+++ b/modules/launch/host/launch-guest/mkosi.extra/usr/local/lib/scripts/launch-guest.sh
@@ -42,4 +42,6 @@ exec qemu-system-x86_64 \
   -machine memory-backend=ram1 \
   -object sev-snp-guest,id=sev0,cbitpos=51,reduced-phys-bits=1,kernel-hashes=on,host-data="${guest_measurement_sha256sum}" \
   -bios ${OVMF_PATH} \
-  -kernel ${EFI_PATH} 2> ${GUEST_ERROR_LOG}
+  -kernel ${EFI_PATH} \
+  -netdev user,id=net0 \
+  -device virtio-net-pci,netdev=net0 2> ${GUEST_ERROR_LOG}

--- a/modules/system/guest/snpguest-ok/mkosi.extra/usr/local/lib/systemd/system/snpguest-ok.service
+++ b/modules/system/guest/snpguest-ok/mkosi.extra/usr/local/lib/systemd/system/snpguest-ok.service
@@ -6,6 +6,7 @@ wants=boot-succesful.service
 
 [Service]
 Type=oneshot
+ExecStartPre=/sbin/modprobe msr
 ExecStart=snpguest ok
 StandardOutput=journal+console
 StandardError=journal+console


### PR DESCRIPTION
This PR is created to:
- Add Ubuntu 26.04 OS support for both guest and host images.
- Enhance guest VM with networking to execute sev-certification workflow on Ubuntu 26.04 image without guest networking errors.
- Fix MSR kernel module loading for snpguest

## Changes
### **Ubuntu 26.04 Support**: 
- Added mkosi configurations for guest and host Ubuntu 26.04 images. 
- Removed unused kernel modules on the host manually to optimize the Ubuntu 26.04 host image size from 1.1G to 800MB
- Included essential guest kernel modules for sev-testing to optimize the Ubuntu 26.04 guest image size from 1.1G to 180MB

### **Guest VM Networking**: 
- Added a networking option to the guest VM launch script as a workaround solution to fix guest networking issues on the Ubuntu 26.04 image.
### **Bug Fix**:
-  Explicitly load msr kernel module as a dependency for the snpguest service

For the Ubuntu 26.04 certificate, please refer to my forked issue posted at the link [https://github.com/LakshmiSaiHarika/snpcert/issues/65](https://github.com/LakshmiSaiHarika/snpcert/issues/65/)

All certificates for this PR can be found in my fork
[https://github.com/LakshmiSaiHarika/snpcert/issues](https://github.com/LakshmiSaiHarika/snpcert/issues)