### PR TITLE
build: add images Makefile, update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@
 /*/image.raw
 /*/image.initrd
 /*/image.vmlinuz
+
+# mkosi build outputs (named after --image-id)
+images/*/tools/
+images/*/*.efi
+images/*/*.initrd
+images/*/*.vmlinuz
+images/*/guest-*
+images/*/host-*

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,0 +1,25 @@
+IMAGES := $(sort $(notdir $(wildcard host-* guest-*)))
+CLEAN_IMAGES := $(addprefix clean-,$(IMAGES))
+
+.PHONY: all clean list status $(IMAGES) $(CLEAN_IMAGES)
+
+all: $(IMAGES)
+
+clean: $(CLEAN_IMAGES)
+
+list:
+	@echo $(IMAGES)
+
+status:
+	@for img in $(IMAGES); do \
+		if [ -e $$img/$$img ]; then \
+			echo "$$img:"; \
+			ls $$img/$$img $$img/$$img.* 2>/dev/null | sed 's/^/\t/'; \
+		fi; \
+	done
+
+$(IMAGES):
+	mkosi --image-id=$@ -C $@ build
+
+$(CLEAN_IMAGES):
+	mkosi --image-id=$(patsubst clean-%,%,$@) -C $(patsubst clean-%,%,$@) clean

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,55 @@
+# Images
+
+mkosi image definitions for SEV-SNP host and guest environments. Each subdirectory contains a `mkosi.conf` for one image.
+
+## Build
+
+```bash
+make list                    # show available images
+make host-fedora-41          # build a specific image
+make all                     # build every image
+make clean-host-fedora-41    # clean a specific image
+make clean                   # clean every image
+make status                  # show built images and their artifacts
+```
+
+## Naming
+
+```
+{role}-{distro}-{release}
+```
+
+- **role**: `host` (bare-metal SEV hypervisor) or `guest` (SEV guest UKI/EFI)
+- **distro**: `fedora`, `ubuntu`, `centos`, `debian`, `rocky`
+- **release**: distro version number or codename
+
+## Ubuntu: AppArmor + mkosi
+
+Ubuntu restricts unprivileged user namespaces via AppArmor, which breaks mkosi. See [systemd/mkosi#3265](https://github.com/systemd/mkosi/issues/3265).
+
+**Quick fix** -- disable the restriction system-wide:
+
+> **Warning:** This disables AppArmor's unprivileged user namespace restrictions for *all* processes, not just mkosi. On multi-user or production systems, prefer the per-binary fix below.
+
+```bash
+sudo sysctl -w kernel.apparmor_restrict_unprivileged_unconfined=0
+sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+```
+
+**Per-binary fix:** Create `/etc/apparmor.d/mkosi` (adjust path if needed):
+
+```
+abi <abi/4.0>,
+include <tunables/global>
+
+profile mkosi /usr/bin/mkosi flags=(unconfined) {
+  userns,
+  include if exists <local/mkosi>
+}
+```
+
+Then reload:
+
+```bash
+sudo systemctl reload apparmor
+```


### PR DESCRIPTION
Some small changes to improve dev experience:
- Makefile for building mkosi images by name. 
- README covers usage and the Ubuntu AppArmor workaround. 
- Gitignore updated for mkosi build outputs.

Makefile Targets:
  - `make list`: show available images
  - `make status`: show built images and their artifacts
  - `make <image>`: build one image (`make host-fedora-41`)
  - `make all`: build every image
  - `make clean-<image>`: clean one image (`make clean-host-fedora-41`)
  - `make clean`: clean every image