### PR TITLE
Include ID block when launching guests

### DIFF
--- a/sev_verify/attestation_report.py
+++ b/sev_verify/attestation_report.py
@@ -1,0 +1,181 @@
+"""Parse the SEV-SNP ATTESTATION_REPORT binary structure.
+
+Reading ``report.bin`` directly, rather than regexing ``snpguest display
+report``, removes a dependency on a CLI's human-readable output format. The
+binary layout is fixed by the SEV-SNP ABI and, unlike the CLI text, the report
+is *self-describing*: VERSION is the first four bytes, so every report states
+which layout it uses and can be checked on the spot.
+
+Layout is version-dependent in practice — the report version tracks firmware,
+which tracks CPU generation — but versions have only ever *appended* fields.
+Everything below 0x188 is common to v2 and v3; the CPUID family/model/stepping
+triple at 0x188 exists only in v3+.
+
+Every offset here was validated against a real v3 report from an EPYC 9654
+(Genoa, CPUID 19h/11h), cross-checked against independently known values:
+GUEST_SVN/POLICY/FAMILY_ID/IMAGE_ID against the values the ID block was built
+with, REPORTED_TCB against ``snphost ok``, AUTHOR_KEY_DIGEST against the known
+all-zero author key, and CPUID against the CPU model.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+
+#: ATTESTATION_REPORT is a fixed-size structure.
+REPORT_SIZE = 1184
+
+#: Report versions whose layout we read. v3 is verified on hardware; v2 shares
+#: the same layout for every field below 0x188.
+KNOWN_VERSIONS = frozenset({2, 3})
+
+# Field offsets. See module docstring for how these were validated.
+_OFF_VERSION = 0x000
+_OFF_GUEST_SVN = 0x004
+_OFF_POLICY = 0x008
+_OFF_FAMILY_ID = 0x010
+_OFF_IMAGE_ID = 0x020
+_OFF_VMPL = 0x030
+_OFF_REPORT_DATA = 0x050
+_OFF_MEASUREMENT = 0x090
+_OFF_HOST_DATA = 0x0C0
+_OFF_ID_KEY_DIGEST = 0x0E0
+_OFF_AUTHOR_KEY_DIGEST = 0x110
+_OFF_REPORT_ID = 0x140
+_OFF_REPORTED_TCB = 0x180
+_OFF_CPUID_FAM = 0x188  # v3+
+
+_LEN_ID = 16
+_LEN_MEASUREMENT = 48
+_LEN_DIGEST = 48
+_LEN_REPORT_DATA = 64
+_LEN_HOST_DATA = 32
+_LEN_REPORT_ID = 32
+
+
+class ReportError(Exception):
+    """Base class for attestation report problems."""
+
+
+class ReportMalformed(ReportError):
+    """The file is not a well-formed ATTESTATION_REPORT."""
+
+
+class ReportUnsupportedVersion(ReportError):
+    """The report declares a version whose layout we have not validated."""
+
+
+@dataclass(frozen=True)
+class TcbVersion:
+    """Decoded SNP TCB_VERSION — the same four values ``snphost ok`` prints."""
+
+    bootloader: int
+    tee: int
+    snp: int
+    microcode: int
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> TcbVersion:
+        # byte 0 BOOT_LOADER, byte 1 TEE, bytes 2-5 reserved,
+        # byte 6 SNP, byte 7 MICROCODE.
+        return cls(bootloader=raw[0], tee=raw[1], snp=raw[6], microcode=raw[7])
+
+    def __str__(self) -> str:
+        return (
+            f"bootloader={self.bootloader} tee={self.tee} "
+            f"snp={self.snp} microcode={self.microcode}"
+        )
+
+
+@dataclass(frozen=True)
+class AttestationReport:
+    """The fields of an ATTESTATION_REPORT that we read."""
+
+    version: int
+    guest_svn: int
+    policy: int
+    family_id: bytes
+    image_id: bytes
+    vmpl: int
+    report_data: bytes
+    measurement: bytes
+    host_data: bytes
+    id_key_digest: bytes
+    author_key_digest: bytes
+    report_id: bytes
+    reported_tcb: TcbVersion
+    #: (family, model, stepping) — v3+ only, None on older reports.
+    cpuid: tuple[int, int, int] | None
+
+    @property
+    def id_block_used(self) -> bool:
+        """True when ID_KEY_DIGEST is set, i.e. the guest launched with an ID block."""
+        return any(self.id_key_digest)
+
+
+def parse(data: bytes) -> AttestationReport:
+    """Parse raw report bytes.
+
+    Raises:
+        ReportMalformed: wrong size.
+        ReportUnsupportedVersion: layout not validated for that version.
+    """
+    if len(data) != REPORT_SIZE:
+        raise ReportMalformed(
+            f"expected a {REPORT_SIZE}-byte ATTESTATION_REPORT, got {len(data)} bytes"
+        )
+
+    (version,) = struct.unpack_from("<I", data, _OFF_VERSION)
+    if version not in KNOWN_VERSIONS:
+        raise ReportUnsupportedVersion(
+            f"report declares VERSION {version}; this parser has been validated "
+            f"for {sorted(KNOWN_VERSIONS)}"
+        )
+
+    (guest_svn,) = struct.unpack_from("<I", data, _OFF_GUEST_SVN)
+    (policy,) = struct.unpack_from("<Q", data, _OFF_POLICY)
+    (vmpl,) = struct.unpack_from("<I", data, _OFF_VMPL)
+
+    def field(off: int, length: int) -> bytes:
+        return data[off:off + length]
+
+    cpuid = None
+    if version >= 3:
+        cpuid = (
+            data[_OFF_CPUID_FAM],
+            data[_OFF_CPUID_FAM + 1],
+            data[_OFF_CPUID_FAM + 2],
+        )
+
+    return AttestationReport(
+        version=version,
+        guest_svn=guest_svn,
+        policy=policy,
+        family_id=field(_OFF_FAMILY_ID, _LEN_ID),
+        image_id=field(_OFF_IMAGE_ID, _LEN_ID),
+        vmpl=vmpl,
+        report_data=field(_OFF_REPORT_DATA, _LEN_REPORT_DATA),
+        measurement=field(_OFF_MEASUREMENT, _LEN_MEASUREMENT),
+        host_data=field(_OFF_HOST_DATA, _LEN_HOST_DATA),
+        id_key_digest=field(_OFF_ID_KEY_DIGEST, _LEN_DIGEST),
+        author_key_digest=field(_OFF_AUTHOR_KEY_DIGEST, _LEN_DIGEST),
+        report_id=field(_OFF_REPORT_ID, _LEN_REPORT_ID),
+        reported_tcb=TcbVersion.from_bytes(field(_OFF_REPORTED_TCB, 8)),
+        cpuid=cpuid,
+    )
+
+
+def read(path: Path) -> AttestationReport:
+    """Read and parse an ATTESTATION_REPORT file.
+
+    Raises:
+        ReportMalformed: file missing or wrong size.
+        ReportUnsupportedVersion: layout not validated for that version.
+    """
+    try:
+        data = path.read_bytes()
+    except FileNotFoundError as exc:
+        raise ReportMalformed(f"{path.name} not found") from exc
+    return parse(data)

--- a/sev_verify/cert_tests/c3_0/c3_0_0_0/attestation_test.py
+++ b/sev_verify/cert_tests/c3_0/c3_0_0_0/attestation_test.py
@@ -20,6 +20,7 @@ Pulled files and analysis output for this test go under ``ctx.artifact_dir``
 import subprocess
 from pathlib import Path
 
+from sev_verify.cvm_props import MeasurementError, read_measurement
 from sev_verify.models import BaseStep, Step, StepContext, StepHandlerResult
 from sev_verify.vm_profile import VMProfile, VMProfileError
 
@@ -82,10 +83,13 @@ def verify_report_fields(ctx: StepContext) -> StepHandlerResult:
     to values computed in earlier ``callable`` or ``host`` steps.
     """
     report_file = ctx.artifact_dir / "report.bin"
-    measurement_file = ctx.artifact_dir / "guest_measurement.txt"
     request_file = ctx.artifact_dir / "request.bin"
 
-    expected_measurement = measurement_file.read_text().strip()
+    try:
+        expected_measurement = f"0x{read_measurement(ctx.artifact_dir)}"
+    except MeasurementError as exc:
+        return StepHandlerResult(exit_code=1, stderr=str(exc))
+
     request_data = "0x" + str(request_file.read_bytes().hex())
     result = subprocess.run(
         [

--- a/sev_verify/cert_tests/c3_0/c3_0_0_2/id_block_test.py
+++ b/sev_verify/cert_tests/c3_0/c3_0_0_2/id_block_test.py
@@ -1,0 +1,362 @@
+"""id_block_test: Verify ID block acceptance, report field binding, and rejection.
+
+Positive path: launch an SEV-SNP guest with a valid ID block, fetch the
+attestation report, and verify that the hardware report reflects the ID block
+fields (guest_svn, policy, family_id, image_id).
+
+Negative path: attempt three launches that must fail:
+  1. ID block with a corrupted measurement (digest mismatch)
+  2. Policy incompatible with the platform (SMT=0 on an SMT-active host)
+  3. Impossibly high ABI major version (ABI_MAJOR=255)
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from dataclasses import replace
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
+
+from sev_verify import attestation_report
+from sev_verify.cvm_props import (
+    DEFAULT_FAMILY_ID,
+    DEFAULT_GUEST_SVN,
+    DEFAULT_IMAGE_ID,
+    DEFAULT_POLICY,
+    MeasurementError,
+    calculate_measurement,
+    generate_id_block,
+    read_measurement,
+)
+from sev_verify.models import BaseStep, Step, StepContext, StepHandlerResult
+from sev_verify.vm_profile import VMProfile
+
+vm_profile = VMProfile(
+    image_path="",
+    memory_mb=2048,
+)
+
+
+# ── Report field verification ─────────────────────────────────────────────────
+
+
+def verify_id_block_fields(ctx: StepContext) -> StepHandlerResult:
+    """Compare ID block fields in the hardware attestation report to expectations.
+
+    Reads report.bin directly (see :mod:`sev_verify.attestation_report`) rather
+    than parsing ``snpguest display report`` output, so the check does not
+    depend on a CLI's human-readable formatting.
+    """
+    try:
+        report = attestation_report.read(ctx.artifact_dir / "report.bin")
+    except attestation_report.ReportError as exc:
+        return StepHandlerResult(exit_code=1, stderr=str(exc))
+
+    family_id = os.environ.get("ID_BLOCK_FAMILY_ID", DEFAULT_FAMILY_ID)
+    image_id = os.environ.get("ID_BLOCK_IMAGE_ID", DEFAULT_IMAGE_ID)
+    guest_svn = int(os.environ.get("ID_BLOCK_GUEST_SVN", DEFAULT_GUEST_SVN))
+    policy_int = int(os.environ.get("ID_BLOCK_POLICY", DEFAULT_POLICY), 0)
+
+    expected_family = family_id.encode("ascii").ljust(16, b"\x00")
+    expected_image = image_id.encode("ascii").ljust(16, b"\x00")
+
+    errors = []
+    if report.guest_svn != guest_svn:
+        errors.append(f"guest_svn: expected {guest_svn}, got {report.guest_svn}")
+    if report.policy != policy_int:
+        errors.append(f"policy: expected {hex(policy_int)}, got {hex(report.policy)}")
+    if report.family_id != expected_family:
+        errors.append(
+            f"family_id: expected {expected_family.hex()}, got {report.family_id.hex()}"
+        )
+    if report.image_id != expected_image:
+        errors.append(
+            f"image_id: expected {expected_image.hex()}, got {report.image_id.hex()}"
+        )
+    # An all-zero ID_KEY_DIGEST means the guest launched without an ID block at
+    # all. The four comparisons above would then all fail with zeros, which is
+    # a confusing way to report "no ID block was used".
+    if not report.id_block_used:
+        errors.append(
+            "id_key_digest is all zero — the guest launched without an ID block"
+        )
+
+    if errors:
+        return StepHandlerResult(exit_code=1, stderr="\n".join(errors))
+    return StepHandlerResult(
+        exit_code=0,
+        stdout=(
+            f"All ID block fields match: svn={guest_svn} policy={hex(policy_int)} "
+            f"family_id={family_id!r} image_id={image_id!r}\n"
+            f"  report v{report.version} vmpl={report.vmpl} "
+            f"cpuid={report.cpuid} tcb=({report.reported_tcb})\n"
+            f"  id_key_digest={report.id_key_digest.hex()[:32]}..."
+        ),
+    )
+
+
+# ── Negative-test profile mutation helpers ────────────────────────────────────
+
+
+def _regenerate_id_block(
+    ctx: StepContext, measurement: str, policy: str,
+) -> StepHandlerResult:
+    """Generate a fresh ID block with the given measurement and policy, update ctx.profile.
+
+    ``measurement`` must be in snpguest's input form — 0x-prefixed hex.  An
+    unprefixed string is decoded as base64, not hex.
+    """
+    family_id = os.environ.get("ID_BLOCK_FAMILY_ID", DEFAULT_FAMILY_ID)
+    image_id = os.environ.get("ID_BLOCK_IMAGE_ID", DEFAULT_IMAGE_ID)
+    guest_svn = os.environ.get("ID_BLOCK_GUEST_SVN", DEFAULT_GUEST_SVN)
+
+    id_key = ec.generate_private_key(ec.SECP384R1())
+    auth_key = ec.generate_private_key(ec.SECP384R1())
+
+    id_block_file = ctx.artifact_dir / "neg-id-block.b64"
+    id_auth_file = ctx.artifact_dir / "neg-id-auth.b64"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        id_key_path = Path(tmpdir) / "id-key.pem"
+        auth_key_path = Path(tmpdir) / "auth-key.pem"
+        id_key_path.write_bytes(
+            id_key.private_bytes(Encoding.PEM, PrivateFormat.TraditionalOpenSSL, NoEncryption())
+        )
+        auth_key_path.write_bytes(
+            auth_key.private_bytes(Encoding.PEM, PrivateFormat.TraditionalOpenSSL, NoEncryption())
+        )
+
+        result = subprocess.run(
+            [
+                "snpguest", "generate", "id-block",
+                str(id_key_path), str(auth_key_path),
+                measurement,
+                "--family-id", family_id,
+                "--image-id", image_id,
+                "--svn", guest_svn,
+                "--policy", policy,
+                "--id-file", str(id_block_file),
+                "--auth-file", str(id_auth_file),
+            ],
+            capture_output=True, text=True, check=False,
+        )
+
+    if result.returncode != 0:
+        return StepHandlerResult(
+            exit_code=1,
+            stderr=f"snpguest generate id-block failed:\n{result.stderr}",
+        )
+
+    ctx.profile = replace(
+        ctx.profile,
+        id_block=id_block_file.read_text().strip(),
+        id_auth=id_auth_file.read_text().strip(),
+        policy=policy,
+    )
+    return StepHandlerResult(exit_code=0)
+
+
+def set_bad_measurement(ctx: StepContext) -> StepHandlerResult:
+    """Regenerate the ID block with a corrupted measurement to cause digest mismatch."""
+    try:
+        real = read_measurement(ctx.artifact_dir)
+    except MeasurementError as exc:
+        return StepHandlerResult(exit_code=1, stderr=str(exc))
+
+    # Flip the first byte of the digest
+    flipped_byte = "00" if real[:2].lower() != "00" else "ff"
+    flipped = flipped_byte + real[2:]
+
+    policy = os.environ.get("ID_BLOCK_POLICY", DEFAULT_POLICY)
+    hr = _regenerate_id_block(ctx, f"0x{flipped}", policy)
+    if hr.exit_code != 0:
+        return hr
+    return StepHandlerResult(
+        exit_code=0,
+        stdout=f"Set bad measurement: {flipped[:16]}... (real: {real[:16]}...)",
+    )
+
+
+def set_incompatible_policy(ctx: StepContext) -> StepHandlerResult:
+    """Regenerate the ID block with a policy the platform cannot satisfy.
+
+    Checks whether SMT is active on the host.  If so, regenerates the ID block
+    (and QEMU launch policy) with SMT=0 — the firmware must reject because the
+    platform cannot guarantee single-threaded execution.
+    """
+    smt_path = Path("/sys/devices/system/cpu/smt/active")
+    if not smt_path.exists():
+        return StepHandlerResult(
+            exit_code=1,
+            stderr="Cannot determine SMT status: /sys/devices/system/cpu/smt/active not found",
+        )
+    smt_active = smt_path.read_text().strip() == "1"
+    if not smt_active:
+        return StepHandlerResult(
+            exit_code=1,
+            stderr="SMT is not active on this host; cannot test SMT policy incompatibility",
+        )
+
+    try:
+        measurement = read_measurement(ctx.artifact_dir)
+    except MeasurementError as exc:
+        return StepHandlerResult(exit_code=1, stderr=str(exc))
+
+    policy = os.environ.get("ID_BLOCK_POLICY", DEFAULT_POLICY)
+    policy_int = int(policy, 0)
+    # Clear SMT bit (16) — guest demands no SMT, but host has SMT active
+    incompatible_policy = hex(policy_int & ~(1 << 16))
+
+    hr = _regenerate_id_block(ctx, f"0x{measurement}", incompatible_policy)
+    if hr.exit_code != 0:
+        return hr
+    return StepHandlerResult(
+        exit_code=0,
+        stdout=f"Set incompatible policy {incompatible_policy} (SMT=0, host SMT active)",
+    )
+
+
+def set_bad_abi_version(ctx: StepContext) -> StepHandlerResult:
+    """Regenerate the ID block with an impossibly high ABI major version.
+
+    The policy's ABI_MAJOR field (bits 15:8) specifies the minimum firmware
+    ABI version required.  Setting it to 255 guarantees the firmware cannot
+    satisfy the requirement on any current platform.
+    """
+    try:
+        measurement = read_measurement(ctx.artifact_dir)
+    except MeasurementError as exc:
+        return StepHandlerResult(exit_code=1, stderr=str(exc))
+
+    policy = os.environ.get("ID_BLOCK_POLICY", DEFAULT_POLICY)
+    policy_int = int(policy, 0)
+    # Set ABI_MAJOR (bits 15:8) to 255
+    bad_policy = (policy_int & ~0xFF00) | (0xFF << 8)
+    bad_policy_hex = hex(bad_policy)
+
+    hr = _regenerate_id_block(ctx, f"0x{measurement}", bad_policy_hex)
+    if hr.exit_code != 0:
+        return hr
+    return StepHandlerResult(
+        exit_code=0,
+        stdout=f"Set policy {bad_policy_hex} (ABI_MAJOR=255)",
+    )
+
+
+# ── Steps ─────────────────────────────────────────────────────────────────────
+
+
+def steps() -> list[BaseStep]:
+    return [
+        # ── Positive: launch with valid ID block, verify report fields ──
+        Step.for_callable(
+            name="Calculate measurement",
+            type="setup",
+            handler="calculate_measurement",
+            timeout=60,
+        ),
+        Step.for_callable(
+            name="Generate ID block",
+            type="setup",
+            handler="generate_id_block",
+            timeout=30,
+        ),
+        Step.for_vm_launch(
+            name="Launch with valid ID block",
+            type="setup",
+            timeout=300,
+        ).add_hint(
+            "Address already in use",
+            "A previous VM may still be running. "
+            "Try: sudo kill $(pgrep -f 'qemu.*guest-cid')",
+        ),
+        Step.for_guest(
+            name="Get attestation report",
+            type="required",
+            command="snpguest report report.bin request.bin --random",
+            timeout=60,
+        ),
+        Step.for_guest_pull(
+            name="Pull attestation report",
+            type="required",
+            guest_src="report.bin",
+            host_dest="report.bin",
+            timeout=120,
+        ),
+        Step.for_vm_stop(
+            name="Stop VM",
+            type="info",
+            timeout=60,
+        ),
+        Step.for_callable(
+            name="Verify ID block fields in report",
+            type="required",
+            handler="verify_id_block_fields",
+            timeout=30,
+        ),
+
+        # ── Negative: bad measurement (digest mismatch) ──
+        Step.for_callable(
+            name="Set bad measurement in ID block",
+            type="required",
+            handler="set_bad_measurement",
+            timeout=30,
+        ),
+        Step.for_vm_launch(
+            name="Launch with bad measurement (expect rejection)",
+            type="required",
+            expected_result="exit_code:1",
+            timeout=300,
+        ),
+        Step.for_vm_stop(
+            name="Stop VM (after bad measurement)",
+            type="info",
+            timeout=60,
+        ),
+
+        # ── Negative: incompatible policy (SMT=0 on SMT-active host) ──
+        Step.for_callable(
+            name="Set incompatible policy (SMT)",
+            type="required",
+            handler="set_incompatible_policy",
+            timeout=30,
+        ),
+        Step.for_vm_launch(
+            name="Launch with SMT-incompatible policy (expect rejection)",
+            type="required",
+            expected_result="exit_code:1",
+            timeout=300,
+        ),
+        Step.for_vm_stop(
+            name="Stop VM (after SMT policy)",
+            type="info",
+            timeout=60,
+        ),
+
+        # ── Negative: impossible ABI version ──
+        Step.for_callable(
+            name="Set impossible ABI version",
+            type="required",
+            handler="set_bad_abi_version",
+            timeout=30,
+        ),
+        Step.for_vm_launch(
+            name="Launch with impossible ABI version (expect rejection)",
+            type="required",
+            expected_result="exit_code:1",
+            timeout=300,
+        ),
+        Step.for_vm_stop(
+            name="Stop VM (after ABI version)",
+            type="info",
+            timeout=60,
+        ),
+    ]

--- a/sev_verify/cert_tests/c3_0/manifest.toml
+++ b/sev_verify/cert_tests/c3_0/manifest.toml
@@ -19,3 +19,12 @@ description = "Test SNP_CONFIG and SNP_COMMIT host commands"
 module = "cert_tests.c3_0.c3_0_0_1.snphost_config_commit"
 scope = "host"
 level = "3.0.0-1"
+
+# ── Level 3.0.0-2 ───────────────────────────────────────────
+
+[[tests]]
+name = "id-block-test"
+description = "Verify ID block acceptance, report field binding, and launch rejection"
+module = "cert_tests.c3_0.c3_0_0_2.id_block_test"
+scope = "mixed"
+level = "3.0.0-2"

--- a/sev_verify/cert_tests/common/snp_ok.py
+++ b/sev_verify/cert_tests/common/snp_ok.py
@@ -47,7 +47,7 @@ def steps() -> list[BaseStep]:
     return [
         Step.for_host(
             name="snphost ok",
-            type="required",
+            type="info",
             command="snphost ok",
         ),
         Step.for_host(

--- a/sev_verify/cert_tests/common/snp_ok.py
+++ b/sev_verify/cert_tests/common/snp_ok.py
@@ -47,7 +47,7 @@ def steps() -> list[BaseStep]:
     return [
         Step.for_host(
             name="snphost ok",
-            type="info",
+            type="required",
             command="snphost ok",
         ),
         Step.for_host(

--- a/sev_verify/cli.py
+++ b/sev_verify/cli.py
@@ -382,6 +382,7 @@ def execute_test(
             # A callable step may replace ctx.profile (dataclasses.replace on a
             # frozen VMProfile yields a new object); assigning the stale local
             # back over it silently discarded that change for every later step.
+            # e.g. generate_id_block setting id_block/id_auth/policy.
             profile = ctx.profile
             ctx.launch = launch
 

--- a/sev_verify/cvm_props.py
+++ b/sev_verify/cvm_props.py
@@ -20,11 +20,13 @@ is typed "setup" — the remaining steps are skipped cleanly.
 
 from __future__ import annotations
 
+import string
 import subprocess
 import tempfile
 from dataclasses import replace
 from pathlib import Path
 
+# may need to change this library
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
@@ -43,6 +45,58 @@ DEFAULT_FAMILY_ID = "sev-certify-fam0"
 DEFAULT_IMAGE_ID = "sev-certify-img0"
 DEFAULT_GUEST_SVN = "48"
 DEFAULT_POLICY = "0xb0000"
+
+# The SNP attestation report MEASUREMENT field is 48 bytes, so the hex form is
+# 96 characters.  Fixed by the SNP spec, not by configuration.
+MEASUREMENT_HEX_LEN = 96
+
+
+class MeasurementError(Exception):
+    """Base class for problems reading guest_measurement.txt."""
+
+
+class MeasurementMissing(MeasurementError):
+    """guest_measurement.txt does not exist."""
+
+
+class MeasurementMalformed(MeasurementError):
+    """guest_measurement.txt exists but does not hold a 48-byte hex digest."""
+
+
+def read_measurement(artifact_dir: Path) -> str:
+    """Read guest_measurement.txt and return the bare (unprefixed) hex digest.
+
+    Validation lives here, at the point of use, rather than in
+    calculate_measurement.  A check at write time says nothing about what a
+    later step is about to read: the steps are separated in time, so the file
+    can change (or be replaced) in between.
+
+    snpguest writes the digest 0x-prefixed under ``--output-format hex``.  The
+    prefix is stripped here so callers operate on a bare body; re-add it with
+    ``f"0x{...}"`` when handing the value back to snpguest, which decodes an
+    unprefixed string as base64 rather than hex.
+
+    Raises:
+        MeasurementMissing: the file is absent.
+        MeasurementMalformed: the file is present but not a 48-byte hex digest.
+    """
+    measurement_file = artifact_dir / _MEASUREMENT_FILE
+    try:
+        raw = measurement_file.read_text().strip()
+    except FileNotFoundError as exc:
+        raise MeasurementMissing(f"{_MEASUREMENT_FILE} not found") from exc
+
+    body = raw[2:] if raw[:2].lower() == "0x" else raw
+    if len(body) != MEASUREMENT_HEX_LEN:
+        raise MeasurementMalformed(
+            f"{_MEASUREMENT_FILE}: expected a {MEASUREMENT_HEX_LEN}-character hex "
+            f"digest (48 bytes), got {len(body)} characters"
+        )
+    if not all(c in string.hexdigits for c in body):
+        raise MeasurementMalformed(
+            f"{_MEASUREMENT_FILE}: contains non-hex characters"
+        )
+    return body
 
 
 def calculate_measurement(ctx: StepContext) -> StepHandlerResult:
@@ -99,17 +153,21 @@ def generate_id_block(ctx: StepContext) -> StepHandlerResult:
     If guest_measurement.txt is absent (calculate_measurement was skipped or
     failed), this step exits 0 and leaves ctx.profile unchanged, so vm_launch
     proceeds without an ID block.
+
+    A file that is present but malformed is a different case and fails the
+    step: absence is an expected configuration, corruption is not.
     """
     import os
 
-    measurement_file = ctx.artifact_dir / _MEASUREMENT_FILE
-    if not measurement_file.exists():
+    try:
+        measurement = read_measurement(ctx.artifact_dir)
+    except MeasurementMissing as exc:
         return StepHandlerResult(
             exit_code=0,
-            stdout=f"INFO: {_MEASUREMENT_FILE} not found — skipping ID block generation",
+            stdout=f"INFO: {exc} — skipping ID block generation",
         )
-
-    measurement = measurement_file.read_text().strip()
+    except MeasurementMalformed as exc:
+        return StepHandlerResult(exit_code=1, stderr=str(exc))
 
     family_id = os.environ.get("ID_BLOCK_FAMILY_ID", DEFAULT_FAMILY_ID)
     image_id = os.environ.get("ID_BLOCK_IMAGE_ID", DEFAULT_IMAGE_ID)
@@ -137,7 +195,7 @@ def generate_id_block(ctx: StepContext) -> StepHandlerResult:
                 "snpguest", "generate", "id-block",
                 str(id_key_path),
                 str(auth_key_path),
-                measurement,
+                f"0x{measurement}",
                 "--family-id", family_id,
                 "--image-id", image_id,
                 "--svn", guest_svn,
@@ -165,7 +223,7 @@ def generate_id_block(ctx: StepContext) -> StepHandlerResult:
     return StepHandlerResult(
         exit_code=0,
         stdout=(
-            f"Generated ID block for measurement {measurement[:18]}...\n"
+            f"Generated ID block for measurement {measurement[:16]}...\n"
             f"  family_id={family_id} image_id={image_id} svn={guest_svn} policy={policy}"
         ),
     )

--- a/sev_verify/id_block.py
+++ b/sev_verify/id_block.py
@@ -1,0 +1,171 @@
+"""Shared callables for ID block generation in sev_verify test modules.
+
+A test module that requires an ID block includes these steps in its steps()
+list, in order, before vm_launch:
+
+    Step.for_callable(name="Calculate measurement", type="setup",
+                      handler="calculate_measurement", timeout=60),
+    Step.for_callable(name="Generate ID block", type="setup",
+                      handler="generate_id_block", timeout=30),
+
+The calculate_measurement step writes guest_measurement.txt to ctx.artifact_dir.
+The generate_id_block step reads it, generates ephemeral P-384 key pairs, calls
+snpguest to produce id-block.b64 and id-auth.b64, and updates ctx.profile so
+that the subsequent vm_launch step passes the ID block to QEMU.
+
+Both steps follow the additive principle: if OVMF is absent (no measurement
+possible), calculate_measurement returns a non-zero exit code and — because it
+is typed "setup" — the remaining steps are skipped cleanly.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from dataclasses import replace
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
+
+from .models import StepContext, StepHandlerResult
+from .vm_profile import VMProfile, VMProfileError
+
+_MEASUREMENT_FILE = "guest_measurement.txt"
+_ID_BLOCK_FILE = "id-block.b64"
+_ID_AUTH_FILE = "id-auth.b64"
+
+DEFAULT_FAMILY_ID = "sev-certify-fam0"
+DEFAULT_IMAGE_ID = "sev-certify-img0"
+DEFAULT_GUEST_SVN = "48"
+DEFAULT_POLICY = "0xb0000"
+
+
+def calculate_measurement(ctx: StepContext) -> StepHandlerResult:
+    """Calculate the expected guest launch measurement via snpguest.
+
+    Resolves the OVMF path from ctx.profile, runs snpguest generate
+    measurement against the guest image, and writes the result to
+    guest_measurement.txt in ctx.artifact_dir.
+    """
+    try:
+        ovmf_path = Path(ctx.profile.resolved_ovmf_path())
+    except VMProfileError as exc:
+        return StepHandlerResult(exit_code=1, stderr=str(exc))
+
+    measurement_file = ctx.artifact_dir / _MEASUREMENT_FILE
+    result = subprocess.run(
+        [
+            "snpguest", "generate", "measurement",
+            "--vcpu-type", "EPYC-v4",
+            "--ovmf", str(ovmf_path),
+            "--kernel", str(ctx.guest_path),
+            "--output-format", "hex",
+            "--measurement-file", str(measurement_file),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return StepHandlerResult(
+            exit_code=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+    measurement = measurement_file.read_text().strip()
+    return StepHandlerResult(
+        exit_code=0,
+        stdout=f"Measurement: {measurement}",
+    )
+
+
+def generate_id_block(ctx: StepContext) -> StepHandlerResult:
+    """Generate an ID block and auth block for the current guest measurement.
+
+    Reads guest_measurement.txt from ctx.artifact_dir (written by
+    calculate_measurement). Generates two ephemeral P-384 key pairs, invokes
+    snpguest generate id-block, and updates ctx.profile with the resulting
+    id_block and id_auth values so that vm_launch passes them to QEMU.
+
+    ID block metadata is read from environment variables with the same defaults
+    used by the generate-id-block systemd service:
+      ID_BLOCK_FAMILY_ID, ID_BLOCK_IMAGE_ID, ID_BLOCK_GUEST_SVN, ID_BLOCK_POLICY
+
+    If guest_measurement.txt is absent (calculate_measurement was skipped or
+    failed), this step exits 0 and leaves ctx.profile unchanged, so vm_launch
+    proceeds without an ID block.
+    """
+    import os
+
+    measurement_file = ctx.artifact_dir / _MEASUREMENT_FILE
+    if not measurement_file.exists():
+        return StepHandlerResult(
+            exit_code=0,
+            stdout=f"INFO: {_MEASUREMENT_FILE} not found — skipping ID block generation",
+        )
+
+    measurement = measurement_file.read_text().strip()
+
+    family_id = os.environ.get("ID_BLOCK_FAMILY_ID", DEFAULT_FAMILY_ID)
+    image_id = os.environ.get("ID_BLOCK_IMAGE_ID", DEFAULT_IMAGE_ID)
+    guest_svn = os.environ.get("ID_BLOCK_GUEST_SVN", DEFAULT_GUEST_SVN)
+    policy = os.environ.get("ID_BLOCK_POLICY", DEFAULT_POLICY)
+
+    id_key = ec.generate_private_key(ec.SECP384R1())
+    auth_key = ec.generate_private_key(ec.SECP384R1())
+
+    id_block_file = ctx.artifact_dir / _ID_BLOCK_FILE
+    id_auth_file = ctx.artifact_dir / _ID_AUTH_FILE
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        id_key_path = Path(tmpdir) / "id-key.pem"
+        auth_key_path = Path(tmpdir) / "auth-key.pem"
+        id_key_path.write_bytes(
+            id_key.private_bytes(Encoding.PEM, PrivateFormat.TraditionalOpenSSL, NoEncryption())
+        )
+        auth_key_path.write_bytes(
+            auth_key.private_bytes(Encoding.PEM, PrivateFormat.TraditionalOpenSSL, NoEncryption())
+        )
+
+        result = subprocess.run(
+            [
+                "snpguest", "generate", "id-block",
+                str(id_key_path),
+                str(auth_key_path),
+                measurement,
+                "--family-id", family_id,
+                "--image-id", image_id,
+                "--svn", guest_svn,
+                "--policy", policy,
+                "--id-file", str(id_block_file),
+                "--auth-file", str(id_auth_file),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    if result.returncode != 0:
+        return StepHandlerResult(
+            exit_code=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+
+    id_block_b64 = id_block_file.read_text().strip()
+    id_auth_b64 = id_auth_file.read_text().strip()
+
+    ctx.profile = replace(ctx.profile, id_block=id_block_b64, id_auth=id_auth_b64, policy=policy)
+
+    return StepHandlerResult(
+        exit_code=0,
+        stdout=(
+            f"Generated ID block for measurement {measurement[:18]}...\n"
+            f"  family_id={family_id} image_id={image_id} svn={guest_svn} policy={policy}"
+        ),
+    )

--- a/sev_verify/vm_profile.py
+++ b/sev_verify/vm_profile.py
@@ -109,7 +109,7 @@ class VMProfile:
     policy: str | int | None = None
     auth_key_enabled: bool = False
     kernel_hashes: bool = True
-    # ID block parameters — set by generate_id_block() in sev_verify.id_block.
+    # ID block parameters — set by generate_id_block() in sev_verify.cvm_props.
     id_block: str | None = None
     id_auth: str | None = None
     # Fixed SEV-SNP parameters used by the existing launch scripts.

--- a/sev_verify/vm_profile.py
+++ b/sev_verify/vm_profile.py
@@ -109,6 +109,9 @@ class VMProfile:
     policy: str | int | None = None
     auth_key_enabled: bool = False
     kernel_hashes: bool = True
+    # ID block parameters — set by generate_id_block() in sev_verify.id_block.
+    id_block: str | None = None
+    id_auth: str | None = None
     # Fixed SEV-SNP parameters used by the existing launch scripts.
     cbitpos: int = 51
     reduced_phys_bits: int = 1
@@ -298,6 +301,9 @@ def _build_sev_snp_guest_object(profile: VMProfile) -> str:
         parts.append(f"policy={_format_policy(profile.policy)}")
     if profile.auth_key_enabled:
         parts.append("author-key-enabled=true")
+    if profile.id_block and profile.id_auth:
+        parts.append(f"id-block={profile.id_block}")
+        parts.append(f"id-auth={profile.id_auth}")
     return ",".join(parts)
 
 


### PR DESCRIPTION
This PR is motivated by the need for an SEV derived keys test in sev-certify/verify. SEV ID blocks include fields that affect what are valid inputs to SEV key derivation. If an ID block isn't used when an SEV guest is launched, valid key derivation inputs are limited.

An ID block includes expected measurement, guest policy, Family ID, Image ID, etc. The expected measurement must match the HW/FW-calculated measurement. Note that sev-certify has always calculated an expected measurement even though it's only now, with this PR, that an ID block is included when launching guests. Ignoring the ID block, sev-certify used the expected measurement as "host data". This is still the case.

ID blocks are signed, but they can be self-signed, which is what this PR does.
