### PR TITLE
fix: add vsock kmods back to ubuntu 26.04

### DIFF
--- a/images/guest-ubuntu-26.04/mkosi.conf
+++ b/images/guest-ubuntu-26.04/mkosi.conf
@@ -15,7 +15,6 @@ Packages=
 	systemd
 	systemd-boot-efi
 	systemd-resolved
-	network-manager
 	plymouth
 	login.defs
 	login
@@ -46,6 +45,9 @@ KernelModulesInclude=
 	drivers/virtio/virtio.ko
 	drivers/virtio/virtio_ring.ko
 	drivers/virtio/virtio_pci.ko
+
+	# vsock support for host-guest communication
+	net/vmw_vsock/
 
 [Build]
 Environment=VERSION="26.04"


### PR DESCRIPTION
Ubuntu 26.04 guest images were timing out when booting with the sev_verify harness. The cause was traced to a missing vsock kmod - add it back. Other images not affected because they don't use the `KernelModulesExclude=.*` setting