### PR TITLE
feat: add max_certification_level manifest field

### DIFF
--- a/sev_verify/cert_tests/c3_0/manifest.toml
+++ b/sev_verify/cert_tests/c3_0/manifest.toml
@@ -1,5 +1,6 @@
 version = "3.0"
 description = "SEV 3.0 Tests (AMD EPYC 7003+)"
+max_certification_level = "3.0.0-0"
 
 # ── Level 3.0.0-0 ───────────────────────────────────────────
 

--- a/sev_verify/cli.py
+++ b/sev_verify/cli.py
@@ -175,6 +175,7 @@ def _filter_tests(
         description=cert.description,
         tests=filtered,
         all_levels=list(cert.all_levels),  # defensive copy
+        max_certification_level=cert.max_certification_level,
     )
 
 
@@ -194,10 +195,15 @@ def load_manifest(toml_path: Path) -> CertificationDefinition:
 
     tests = _load_test_entries(toml_path, data)
 
+    max_cert_level = data.get("max_certification_level")
+    if max_cert_level is not None:
+        max_cert_level = str(max_cert_level)
+
     return CertificationDefinition(
         version=str(data["version"]),
         description=str(data["description"]),
         tests=tests,
+        max_certification_level=max_cert_level,
     )
 
 
@@ -489,6 +495,8 @@ def execute_certification(
 
     _section(f"Certification {cert.version}")
     _flush(f"   {cert.description}")
+    if cert.max_certification_level:
+        _flush(f"   Max certification level: {cert.max_certification_level}")
     _flush("")
 
     current_level = None
@@ -531,6 +539,10 @@ def _highest_certified_level(cr: CertificationResult) -> str | None:
     achieved only if every prior level was also run and passed.
     Returns None if no contiguous chain of passing levels exists
     (e.g. level 0 was skipped or failed).
+
+    When ``max_certification_level`` is set on the certification, the
+    result is clamped so it never exceeds that cap — even if higher
+    levels ran and passed.
     """
     # Build a map: level -> list of results for tests at that level
     results_by_level: dict[str, list[str]] = {}
@@ -548,6 +560,14 @@ def _highest_certified_level(cr: CertificationResult) -> str | None:
             # Level had a failure — chain broken
             break
         highest = level
+
+    # Clamp to max_certification_level if set.
+    cap = cr.certification.max_certification_level
+    if highest is not None and cap is not None:
+        all_levels = cr.certification.all_levels
+        if all_levels.index(cap) < all_levels.index(highest):
+            highest = cap
+
     return highest
 
 

--- a/sev_verify/models.py
+++ b/sev_verify/models.py
@@ -302,6 +302,9 @@ class CertificationDefinition:
     tests: list[TestDefinition] = field(default_factory=list)
     # Ordered unique levels from the original manifest (preserved across filtering for chain validation)
     all_levels: list[str] = field(default_factory=list)
+    # Optional cap on the highest achievable certification level.
+    # Tests above this level still run but the final certified level is clamped.
+    max_certification_level: str | None = None
 
     def __post_init__(self) -> None:
         if not self.version:
@@ -313,6 +316,13 @@ class CertificationDefinition:
                 if t.level and t.level not in seen:
                     seen.add(t.level)
                     self.all_levels.append(t.level)
+        # Validate max_certification_level against known levels.
+        if self.max_certification_level is not None:
+            if self.all_levels and self.max_certification_level not in self.all_levels:
+                raise ValueError(
+                    f"max_certification_level {self.max_certification_level!r} "
+                    f"is not a valid level; expected one of {self.all_levels}"
+                )
 
 
 # ── Runtime result models (populated during execution) ──────────

--- a/sev_verify/output.py
+++ b/sev_verify/output.py
@@ -91,12 +91,13 @@ def write_json(
             "tests": [_test_dict(tr) for tr in trs],
         })
 
-    doc = {
+    doc: dict[str, Any] = {
         "schema_version": "1.0",
         "certification_version": cr.certification.version,
         "description": cr.certification.description,
         "result": cr.result,
         "certified_level": certified_level,
+        "max_certification_level": cr.certification.max_certification_level,
         "started_at": cr.started_at,
         "completed_at": cr.completed_at,
         "levels": levels_out,
@@ -133,6 +134,8 @@ def write_markdown(
     w(f"## SEV Certification {cr.certification.version} -- {result_label}")
     w("")
     w(f"**Certified level:** {certified_level or 'none'}")
+    if cr.certification.max_certification_level:
+        w(f"**Max certification level:** {cr.certification.max_certification_level}")
     w(f"**Started:** {cr.started_at}")
     w(f"**Completed:** {cr.completed_at}")
     w("")


### PR DESCRIPTION
Add optional max_certification_level top-level field to TOML manifests. Tests above the max still run and report results, but do not affect the final certified level.

This change allows tests to be grouped under a certification level without too much coordination.

Currently will cap the 3.0 manifest at 3.0.0-0.