### PR TITLE
Certificate Format Updates

### DIFF
--- a/sev_verify/cli.py
+++ b/sev_verify/cli.py
@@ -607,11 +607,12 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         ovmf_override = str(args.ovmf.resolve())
 
-    # Resolve effective OVMF path for environment detection
+    # Resolve effective binaries for environment detection
+    effective_qemu = qemu_override or DEFAULT_QEMU_BINARY
     effective_ovmf = ovmf_override or find_ovmf_path()
 
     environment = detect_environment(
-        qemu_binary=qemu_override or DEFAULT_QEMU_BINARY,
+        qemu_binary=effective_qemu,
         ovmf_path=effective_ovmf,
     )
 
@@ -634,8 +635,8 @@ def main(argv: list[str] | None = None) -> int:
         _flush(f"   Kernel: {environment['kernel_version']}")
     if environment.get("qemu_version"):
         _flush(f"   QEMU:   {environment['qemu_version']}")
-    elif qemu_override:
-        _flush(f"   QEMU:   {qemu_override}")
+    elif effective_qemu:
+        _flush(f"   QEMU:   {effective_qemu}")
     if environment.get("ovmf_version"):
         _flush(f"   OVMF:   {environment['ovmf_version']}")
     elif effective_ovmf:

--- a/sev_verify/cli.py
+++ b/sev_verify/cli.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from .environment import detect_environment
+from .os_info import update_environment_with_guest_os
 from .models import (
     CertificationDefinition,
     CertificationResult,
@@ -320,6 +321,7 @@ def execute_test(
     certification_version: str | None = None,
     qemu_binary: str | None = None,
     ovmf_path: str | None = None,
+    environment: dict[str, str | None] | None = None,
 ) -> TestResult:
     """Run a test, printing each step live as it executes."""
     started_at = datetime.now(timezone.utc).isoformat()
@@ -400,6 +402,8 @@ def execute_test(
                 else:
                     sr, new_launch = run_vm_launch_step(step, profile)
                     launch = new_launch
+                    if launch is not None and launch.ok and environment is not None:
+                        update_environment_with_guest_os(environment, launch.profile)
             elif step.kind == "vm_stop":
                 if launch is None:
                     sr = StepResult(
@@ -424,6 +428,8 @@ def execute_test(
                 else:
                     if launch is None:
                         launch = profile.vm_launch()
+                        if launch.ok and environment is not None:
+                            update_environment_with_guest_os(environment, launch.profile)
                     if not launch.ok:
                         sr = StepResult(
                             step=step,
@@ -493,6 +499,7 @@ def execute_certification(
     artifacts_root: Path,
     qemu_binary: str | None = None,
     ovmf_path: str | None = None,
+    environment: dict[str, str | None] | None = None,
 ) -> CertificationResult:
     """Run all tests in a certification with live output."""
     started_at = datetime.now(timezone.utc).isoformat()
@@ -519,6 +526,7 @@ def execute_certification(
             certification_version=cert.version,
             qemu_binary=qemu_binary,
             ovmf_path=ovmf_path,
+            environment=environment,
         )
         test_results.append(tr)
         if tr.result != "pass":
@@ -620,6 +628,8 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     _flush(f"   Guest:  {guest_path}")
+    if environment.get("host_os_pretty_name"):
+        _flush(f"   Host:   {environment['host_os_pretty_name']}")
     if environment.get("kernel_version"):
         _flush(f"   Kernel: {environment['kernel_version']}")
     if environment.get("qemu_version"):
@@ -649,6 +659,7 @@ def main(argv: list[str] | None = None) -> int:
                 certification_version=None,
                 qemu_binary=qemu_override,
                 ovmf_path=ovmf_override,
+                environment=environment,
             )
             prereq_results.append(tr)
             _flush("")
@@ -683,6 +694,7 @@ def main(argv: list[str] | None = None) -> int:
             artifacts_root=args.artifacts_dir,
             qemu_binary=qemu_override,
             ovmf_path=ovmf_override,
+            environment=environment,
         )
         cert_results.append(cr)
         total_tests += len(cr.test_results)

--- a/sev_verify/cli.py
+++ b/sev_verify/cli.py
@@ -9,6 +9,7 @@ import tomllib
 from datetime import datetime, timezone
 from pathlib import Path
 
+from .environment import detect_environment
 from .models import (
     CertificationDefinition,
     CertificationResult,
@@ -30,7 +31,12 @@ from .runner import (
     run_vm_stop_step,
     test_artifact_dir,
 )
-from .vm_profile import VMLaunchResult, stop_vm
+from .vm_profile import (
+    DEFAULT_QEMU_BINARY,
+    find_ovmf_path,
+    VMLaunchResult,
+    stop_vm,
+)
 
 _LINE_WIDTH = 80
 
@@ -593,6 +599,14 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         ovmf_override = str(args.ovmf.resolve())
 
+    # Resolve effective OVMF path for environment detection
+    effective_ovmf = ovmf_override or find_ovmf_path()
+
+    environment = detect_environment(
+        qemu_binary=qemu_override or DEFAULT_QEMU_BINARY,
+        ovmf_path=effective_ovmf,
+    )
+
     cert_dir = Path(__file__).resolve().parent / "cert_tests"
 
     version_filters = _parse_version_filters(args.versions)
@@ -605,11 +619,17 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    _flush(f"   Guest: {guest_path}")
-    if qemu_override:
-        _flush(f"   QEMU:  {qemu_override}")
-    if ovmf_override:
-        _flush(f"   OVMF:  {ovmf_override}")
+    _flush(f"   Guest:  {guest_path}")
+    if environment.get("kernel_version"):
+        _flush(f"   Kernel: {environment['kernel_version']}")
+    if environment.get("qemu_version"):
+        _flush(f"   QEMU:   {environment['qemu_version']}")
+    elif qemu_override:
+        _flush(f"   QEMU:   {qemu_override}")
+    if environment.get("ovmf_version"):
+        _flush(f"   OVMF:   {environment['ovmf_version']}")
+    elif effective_ovmf:
+        _flush(f"   OVMF:   {effective_ovmf}")
     _flush("")
 
     total_tests = 0
@@ -669,8 +689,8 @@ def main(argv: list[str] | None = None) -> int:
         total_passed += sum(1 for tr in cr.test_results if tr.result == "pass")
 
         certified_level = _highest_certified_level(cr)
-        json_path = write_json(cr, certified_level, args.output_dir)
-        md_path = write_markdown(cr, certified_level, args.output_dir)
+        json_path = write_json(cr, certified_level, args.output_dir, environment=environment)
+        md_path = write_markdown(cr, certified_level, args.output_dir, environment=environment)
         _flush(f"   Wrote {json_path}")
         _flush(f"   Wrote {md_path}")
         _flush("")

--- a/sev_verify/environment.py
+++ b/sev_verify/environment.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import platform
 import shutil
 import subprocess
@@ -38,6 +39,9 @@ def _get_kernel_version() -> str | None:
 
 def _get_ovmf_version(path: str) -> str | None:
     """Try dpkg then rpm to find the package version owning *path*."""
+    if not os.path.exists(path):
+        return None
+
     # dpkg -S /path -> "package: /path"
     try:
         proc = subprocess.run(
@@ -83,6 +87,7 @@ def detect_environment(
     host_os = get_host_os_info()
     return {
         "qemu_version": _get_qemu_version(qemu_binary),
+        "qemu_binary": qemu_binary,
         "kernel_version": _get_kernel_version(),
         "ovmf_version": _get_ovmf_version(ovmf_path) if ovmf_path else None,
         "ovmf_path": ovmf_path,

--- a/sev_verify/environment.py
+++ b/sev_verify/environment.py
@@ -1,10 +1,12 @@
-"""Detect host environment versions (QEMU, kernel, OVMF) for reporting."""
+"""Detect host environment versions (QEMU, kernel, OVMF, OS) for reporting."""
 
 from __future__ import annotations
 
 import platform
 import shutil
 import subprocess
+
+from .os_info import get_host_os_info
 
 
 def _get_qemu_version(binary: str) -> str | None:
@@ -78,9 +80,13 @@ def detect_environment(
 
     All detection is best-effort: failures produce ``None`` values.
     """
+    host_os = get_host_os_info()
     return {
         "qemu_version": _get_qemu_version(qemu_binary),
         "kernel_version": _get_kernel_version(),
         "ovmf_version": _get_ovmf_version(ovmf_path) if ovmf_path else None,
         "ovmf_path": ovmf_path,
+        "host_os_name": host_os.get("host_os_name"),
+        "host_os_release": host_os.get("host_os_release"),
+        "host_os_pretty_name": host_os.get("host_os_pretty_name"),
     }

--- a/sev_verify/environment.py
+++ b/sev_verify/environment.py
@@ -1,0 +1,86 @@
+"""Detect host environment versions (QEMU, kernel, OVMF) for reporting."""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+
+
+def _get_qemu_version(binary: str) -> str | None:
+    """Run ``<binary> --version`` and parse the version string."""
+    resolved = shutil.which(binary)
+    if not resolved:
+        return None
+    try:
+        proc = subprocess.run(
+            [resolved, "--version"],
+            capture_output=True, text=True, timeout=5,
+        )
+        first_line = proc.stdout.split("\n", 1)[0]
+        prefix = "QEMU emulator version "
+        if first_line.startswith(prefix):
+            return first_line[len(prefix):]
+        return None
+    except Exception:
+        return None
+
+
+def _get_kernel_version() -> str | None:
+    """Return the running kernel release string."""
+    try:
+        return platform.release()
+    except Exception:
+        return None
+
+
+def _get_ovmf_version(path: str) -> str | None:
+    """Try dpkg then rpm to find the package version owning *path*."""
+    # dpkg -S /path -> "package: /path"
+    try:
+        proc = subprocess.run(
+            ["dpkg", "-S", path],
+            capture_output=True, text=True, timeout=5,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            pkg = proc.stdout.strip().split(":", 1)[0]
+            info = subprocess.run(
+                ["dpkg", "-s", pkg],
+                capture_output=True, text=True, timeout=5,
+            )
+            for line in info.stdout.splitlines():
+                if line.startswith("Version:"):
+                    version = line.split(":", 1)[1].strip()
+                    return f"{version} ({pkg})"
+    except Exception:
+        pass
+
+    # rpm -qf /path -> "package-version"
+    try:
+        proc = subprocess.run(
+            ["rpm", "-qf", path],
+            capture_output=True, text=True, timeout=5,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            return proc.stdout.strip()
+    except Exception:
+        pass
+
+    return None
+
+
+def detect_environment(
+    *,
+    qemu_binary: str = "qemu-system-x86_64",
+    ovmf_path: str | None = None,
+) -> dict[str, str | None]:
+    """Return a dict of detected host component versions.
+
+    All detection is best-effort: failures produce ``None`` values.
+    """
+    return {
+        "qemu_version": _get_qemu_version(qemu_binary),
+        "kernel_version": _get_kernel_version(),
+        "ovmf_version": _get_ovmf_version(ovmf_path) if ovmf_path else None,
+        "ovmf_path": ovmf_path,
+    }

--- a/sev_verify/os_info.py
+++ b/sev_verify/os_info.py
@@ -35,7 +35,7 @@ def get_host_os_info(os_release_path: str = "/etc/os-release") -> dict[str, str 
     """
     try:
         content = Path(os_release_path).read_text()
-    except OSError:
+    except (OSError, UnicodeError):
         return {
             "host_os_name": None,
             "host_os_release": None,
@@ -118,7 +118,7 @@ def update_environment_with_guest_os(
     Requires an active guest with vsock agent. Silently skips if guest
     info cannot be retrieved.
     """
-    if environment.get("guest_os_pretty_name"):
+    if "guest_os_pretty_name" in environment:
         return
 
     guest_info = get_guest_os_info(profile)

--- a/sev_verify/os_info.py
+++ b/sev_verify/os_info.py
@@ -1,0 +1,128 @@
+"""Detect Host and Guest OS name and release information."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .vm_profile import VMProfile
+
+
+def _parse_os_release(content: str) -> dict[str, str]:
+    """Parse /etc/os-release content into a dict."""
+    result: dict[str, str] = {}
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        value = value.strip('"').strip("'")
+        result[key] = value
+    return result
+
+
+def get_host_os_info(os_release_path: str = "/etc/os-release") -> dict[str, str | None]:
+    """Read host OS name and release from /etc/os-release.
+
+    Returns a dict with keys:
+        - host_os_name: e.g. "Fedora Linux"
+        - host_os_release: e.g. "41 (Server Edition)"
+        - host_os_pretty_name: e.g. "Fedora Linux 41 (Server Edition)"
+        - host_os_id: e.g. "fedora"
+    """
+    try:
+        content = Path(os_release_path).read_text()
+    except OSError:
+        return {
+            "host_os_name": None,
+            "host_os_release": None,
+            "host_os_pretty_name": None,
+            "host_os_id": None,
+        }
+
+    data = _parse_os_release(content)
+    return {
+        "host_os_name": data.get("NAME"),
+        "host_os_release": data.get("VERSION"),
+        "host_os_pretty_name": data.get("PRETTY_NAME"),
+        "host_os_id": data.get("ID"),
+    }
+
+
+def get_guest_os_info(profile: "VMProfile") -> dict[str, str | None]:
+    """Read guest OS name and release via vsock command.
+
+    Requires an active guest with vsock agent running.
+
+    Returns a dict with keys:
+        - guest_os_name: e.g. "Ubuntu"
+        - guest_os_release: e.g. "24.04 LTS (Noble Numbat)"
+        - guest_os_pretty_name: e.g. "Ubuntu 24.04 LTS"
+        - guest_os_id: e.g. "ubuntu"
+    """
+    from .guest_vsock import run_guest_command, GuestVsockError
+
+    try:
+        result = run_guest_command(profile, "cat /etc/os-release", timeout=10)
+        if result.exit_code != 0:
+            return {
+                "guest_os_name": None,
+                "guest_os_release": None,
+                "guest_os_pretty_name": None,
+                "guest_os_id": None,
+            }
+
+        data = _parse_os_release(result.stdout)
+        return {
+            "guest_os_name": data.get("NAME"),
+            "guest_os_release": data.get("VERSION"),
+            "guest_os_pretty_name": data.get("PRETTY_NAME"),
+            "guest_os_id": data.get("ID"),
+        }
+    except GuestVsockError:
+        return {
+            "guest_os_name": None,
+            "guest_os_release": None,
+            "guest_os_pretty_name": None,
+            "guest_os_id": None,
+        }
+
+
+def format_os_info(os_info: dict[str, str | None]) -> str | None:
+    """Format OS info dict into a single display string.
+
+    Prefers PRETTY_NAME if available, otherwise combines NAME and VERSION.
+    Returns None if no info is available.
+    """
+    pretty = os_info.get("host_os_pretty_name") or os_info.get("guest_os_pretty_name")
+    if pretty:
+        return pretty
+
+    name = os_info.get("host_os_name") or os_info.get("guest_os_name")
+    release = os_info.get("host_os_release") or os_info.get("guest_os_release")
+
+    if name and release:
+        return f"{name} {release}"
+    return name or release or None
+
+
+def update_environment_with_guest_os(
+    environment: dict[str, str | None],
+    profile: "VMProfile",
+) -> None:
+    """Update environment dict in-place with guest OS information.
+
+    Requires an active guest with vsock agent. Silently skips if guest
+    info cannot be retrieved.
+    """
+    if environment.get("guest_os_pretty_name"):
+        return
+
+    guest_info = get_guest_os_info(profile)
+    environment["guest_os_name"] = guest_info.get("guest_os_name")
+    environment["guest_os_release"] = guest_info.get("guest_os_release")
+    environment["guest_os_pretty_name"] = guest_info.get("guest_os_pretty_name")
+    environment["guest_os_id"] = guest_info.get("guest_os_id")

--- a/sev_verify/output.py
+++ b/sev_verify/output.py
@@ -72,6 +72,8 @@ def write_json(
     cr: CertificationResult,
     certified_level: str | None,
     output_dir: Path,
+    *,
+    environment: dict[str, str | None] | None = None,
 ) -> Path:
     """Write machine-readable JSON certification result."""
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -100,6 +102,7 @@ def write_json(
         "max_certification_level": cr.certification.max_certification_level,
         "started_at": cr.started_at,
         "completed_at": cr.completed_at,
+        "environment": environment or {},
         "levels": levels_out,
     }
 
@@ -123,6 +126,8 @@ def write_markdown(
     cr: CertificationResult,
     certified_level: str | None,
     output_dir: Path,
+    *,
+    environment: dict[str, str | None] | None = None,
 ) -> Path:
     """Write human-readable Markdown certification report."""
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -131,7 +136,10 @@ def write_markdown(
     lines: list[str] = []
     w = lines.append
 
-    w(f"## SEV Certification {cr.certification.version} -- {result_label}")
+    if certified_level:
+        w(f"# Achieved Certification Level {certified_level}")
+    else:
+        w("# Failed to Achieve a Certification Level")
     w("")
     w(f"**Certified level:** {certified_level or 'none'}")
     if cr.certification.max_certification_level:
@@ -139,6 +147,23 @@ def write_markdown(
     w(f"**Started:** {cr.started_at}")
     w(f"**Completed:** {cr.completed_at}")
     w("")
+
+    if environment:
+        env_lines: list[str] = []
+        if environment.get("kernel_version"):
+            env_lines.append(f"- **Host kernel:** {environment['kernel_version']}")
+        if environment.get("qemu_version"):
+            env_lines.append(f"- **QEMU:** {environment['qemu_version']}")
+        if environment.get("ovmf_version"):
+            env_lines.append(f"- **OVMF:** {environment['ovmf_version']}")
+        elif environment.get("ovmf_path"):
+            env_lines.append(f"- **OVMF:** {environment['ovmf_path']}")
+        if env_lines:
+            w("## Environment")
+            w("")
+            for el in env_lines:
+                w(el)
+            w("")
 
     # Group tests by level
     tests_by_level, unlabeled = _group_tests_by_level(cr.test_results)

--- a/sev_verify/output.py
+++ b/sev_verify/output.py
@@ -102,9 +102,11 @@ def write_json(
         "max_certification_level": cr.certification.max_certification_level,
         "started_at": cr.started_at,
         "completed_at": cr.completed_at,
-        "environment": environment or {},
         "levels": levels_out,
     }
+
+    if environment:
+        doc["environment"] = environment
 
     if unlabeled:
         doc["unlabeled_tests"] = [_test_dict(tr) for tr in unlabeled]
@@ -132,7 +134,6 @@ def write_markdown(
     """Write human-readable Markdown certification report."""
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    result_label = "PASS" if cr.result == "pass" else "FAIL"
     lines: list[str] = []
     w = lines.append
 
@@ -168,6 +169,8 @@ def write_markdown(
             env_lines.append(f"- **Guest OS:** {guest_os}")
         if environment.get("qemu_version"):
             env_lines.append(f"- **QEMU:** {environment['qemu_version']}")
+        elif environment.get("qemu_binary"):
+            env_lines.append(f"- **QEMU:** {environment['qemu_binary']}")
         if environment.get("ovmf_version"):
             env_lines.append(f"- **OVMF:** {environment['ovmf_version']}")
         elif environment.get("ovmf_path"):

--- a/sev_verify/output.py
+++ b/sev_verify/output.py
@@ -150,8 +150,22 @@ def write_markdown(
 
     if environment:
         env_lines: list[str] = []
+        if environment.get("host_os_pretty_name"):
+            env_lines.append(f"- **Host OS:** {environment['host_os_pretty_name']}")
+        elif environment.get("host_os_name"):
+            host_os = environment["host_os_name"]
+            if environment.get("host_os_release"):
+                host_os = f"{host_os} {environment['host_os_release']}"
+            env_lines.append(f"- **Host OS:** {host_os}")
         if environment.get("kernel_version"):
             env_lines.append(f"- **Host kernel:** {environment['kernel_version']}")
+        if environment.get("guest_os_pretty_name"):
+            env_lines.append(f"- **Guest OS:** {environment['guest_os_pretty_name']}")
+        elif environment.get("guest_os_name"):
+            guest_os = environment["guest_os_name"]
+            if environment.get("guest_os_release"):
+                guest_os = f"{guest_os} {environment['guest_os_release']}"
+            env_lines.append(f"- **Guest OS:** {guest_os}")
         if environment.get("qemu_version"):
             env_lines.append(f"- **QEMU:** {environment['qemu_version']}")
         if environment.get("ovmf_version"):

--- a/sev_verify/vm_profile.py
+++ b/sev_verify/vm_profile.py
@@ -135,7 +135,7 @@ class VMProfile:
         return cls(**{k: v for k, v in normalized.items() if k in known})
 
     def resolved_ovmf_path(self) -> str:
-        """"
+        """
         Verify provided OVMF path is present.
 
         If not, look for OVMF on default locations.

--- a/sev_verify/vm_profile.py
+++ b/sev_verify/vm_profile.py
@@ -22,6 +22,15 @@ DEFAULT_OVMF_CANDIDATES = (
     "/usr/share/edk2/ovmf/OVMF.amdsev.fd",
 )
 
+
+def find_ovmf_path() -> str | None:
+    """Return the first existing OVMF candidate path, or None."""
+    for candidate in DEFAULT_OVMF_CANDIDATES:
+        if Path(candidate).is_file():
+            return candidate
+    return None
+
+
 DEFAULT_GUEST_ERROR_LOG = "/tmp/guest-error.log"
 DEFAULT_QEMU_BINARY = "qemu-system-x86_64"
 DEFAULT_MEMORY_MB = 2048
@@ -136,9 +145,9 @@ class VMProfile:
             if not path.is_file():
                 raise VMProfileError(f"OVMF firmware not found on provided path: {self.ovmf_path}")
             return str(path)
-        for candidate in DEFAULT_OVMF_CANDIDATES:
-            if Path(candidate).is_file():
-                return candidate
+        found = find_ovmf_path()
+        if found:
+            return found
         raise VMProfileError(
             "AMD SEV-compatible OVMF is not present; cannot launch SEV-SNP guest. "
             f"Tried: {', '.join(DEFAULT_OVMF_CANDIDATES)}"


### PR DESCRIPTION
Adds host and guest environment detection to certification reports so results include the exact software versions used during the run.

  - All detection is best-effort - failures produce `None`, never errors.
  - Guest OS detection happens lazily on first successful VM launch, then is cached in the environment dict.
  - The environment dict is threaded through existing call chains rather than stored as global state.
  - guest kernel reporting to be added in a follow-up PR.

<details>
  <summary>Example Certification Formatting</summary>

# Achieved Certification Level 3.0.0-1

**Certified level:** 3.0.0-1
**Started:** 2026-06-30T23:04:58.182398+00:00
**Completed:** 2026-06-30T23:05:13.829545+00:00

## Environment

- **Host OS:** Ubuntu 25.04
- **Host kernel:** 6.14.0-37-generic
- **Guest OS:** Ubuntu 26.04 LTS
- **QEMU:** 9.2.1 (Debian 1:9.2.1+ds-1ubuntu5.2)
- **OVMF:** 2025.02-3ubuntu2.2 (ovmf)

### Level 3.0.0-0

| Test | Scope | Result |
|------|-------|--------|
| attestation-test | mixed | :white_check_mark: |

### Level 3.0.0-1

| Test | Scope | Result |
|------|-------|--------|
| snphost-config-commit | host | :white_check_mark: |


</details>
