### PR TITLE
fix: use linux-image-virtual metapackage for ubuntu 25.10 and 26.04

### DIFF
--- a/images/guest-ubuntu-25.10/mkosi.conf
+++ b/images/guest-ubuntu-25.10/mkosi.conf
@@ -8,8 +8,7 @@ Repositories=universe
 
 [Content]
 Packages=
-	linux-image-6.17.0-8-generic
-    linux-modules-6.17.0-8-generic
+	linux-image-virtual
 	systemd
 	systemd-boot-efi
 	systemd-resolved

--- a/images/guest-ubuntu-26.04/mkosi.conf
+++ b/images/guest-ubuntu-26.04/mkosi.conf
@@ -9,9 +9,7 @@ RepositoryKeyFetch=yes
 
 [Content]
 Packages=
-	linux-image-generic
-	linux-modules-*-generic
-	linux-modules-extra-*
+	linux-image-virtual
 	systemd
 	systemd-boot-efi
 	systemd-resolved

--- a/images/host-ubuntu-25.10/mkosi.conf
+++ b/images/host-ubuntu-25.10/mkosi.conf
@@ -9,7 +9,7 @@ RepositoryKeyFetch=yes
 
 [Content]
 Packages=
-	linux-image-6.17.0-8-generic
+	linux-image-virtual
 	systemd
 	systemd-boot-efi
 	systemd-resolved

--- a/images/host-ubuntu-26.04/mkosi.conf
+++ b/images/host-ubuntu-26.04/mkosi.conf
@@ -9,9 +9,7 @@ RepositoryKeyFetch=yes
 
 [Content]
 Packages=
-	linux-modules-*-generic
-	linux-image-generic
-	linux-modules-extra-*
+	linux-image-virtual
 	systemd
 	systemd-boot-efi
 	systemd-resolved


### PR DESCRIPTION
Use `linux-image-virtual` package to specify default kernel package for the distro.

Pinned kernel versions get removed from repos when Ubuntu publishes newer point releases, breaking image builds:
`E: Unable to locate package linux-modules-6.17.0-8-generic` in https://github.com/AMDEPYC/sev-certify/actions/runs/28899258652/job/85733213329

Use linux-image-virtual metapackage which tracks the current kernel without pulling in firmware blobs (linux-firmware, intel-microcode, amd64-microcode). Using linux-image-virtual vs linux-image-generic appears to save ~500MB. Making the change to 26.04 as well, since that same CI run failed for 26.04 when the host image size became > 1G.

I tested both changes on my fork and got passing results:
- https://github.com/amd-aliem/sev-certify/issues/190
- https://github.com/amd-aliem/sev-certify/issues/191