### PR TITLE
build: add tags local build option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ images/*/*.initrd
 images/*/*.vmlinuz
 images/*/guest-*
 images/*/host-*
+images/.tags
 
 results/
 artifacts/

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,7 +1,30 @@
 IMAGES := $(sort $(notdir $(wildcard host-* guest-*)))
 CLEAN_IMAGES := $(addprefix clean-,$(IMAGES))
 
-.PHONY: all clean list status $(IMAGES) $(CLEAN_IMAGES)
+GH_AUTH := $(if $(GITHUB_TOKEN),-H "Authorization: Bearer $(GITHUB_TOKEN)")
+GH_LATEST = curl -sf $(GH_AUTH) https://api.github.com/repos/$(1)/releases/latest | jq -r '.tag_name'
+
+.PHONY: all clean list status tags $(IMAGES) $(CLEAN_IMAGES)
+
+tags:
+	@set -e; \
+	trap 'rm -f .tags.tmp' EXIT; \
+	fetch() { \
+		tag=$$($(call GH_LATEST,$$1)); \
+		if [ -z "$$tag" ] || [ "$$tag" = "null" ]; then \
+			echo "Failed to fetch tag for $$1. Try: export GITHUB_TOKEN=\$$(gh auth token)" >&2; \
+			exit 1; \
+		fi; \
+		echo "$$2=$$tag"; \
+	}; \
+	{ fetch virtee/snpguest SNPGUEST_TAG; \
+	  fetch AMDEPYC/beacon   BEACON_TAG; \
+	  fetch virtee/snphost   SNPHOST_TAG; } > .tags.tmp; \
+	mv .tags.tmp .tags
+	@cat .tags
+
+.tags:
+	@echo "Missing .tags — run 'make tags' first to fetch component versions." >&2; exit 1
 
 all: $(IMAGES)
 
@@ -18,8 +41,8 @@ status:
 		fi; \
 	done
 
-$(IMAGES):
-	mkosi --image-id=$@ -C $@ build
+$(IMAGES): | .tags
+	mkosi --image-id=$@ -C $@ --env-file=../.tags build
 
 $(CLEAN_IMAGES):
 	mkosi --image-id=$(patsubst clean-%,%,$@) -C $(patsubst clean-%,%,$@) clean

--- a/images/README.md
+++ b/images/README.md
@@ -4,6 +4,35 @@ mkosi image definitions for SEV-SNP host and guest environments. Each subdirecto
 
 ## Build
 
+### 1. Fetch dependency tags
+
+```bash
+make tags
+```
+
+This queries the GitHub API for the latest release tag of each build dependency and writes them to `.tags`:
+
+| Variable | Repository | Used by |
+|---|---|---|
+| `SNPGUEST_TAG` | [virtee/snpguest](https://github.com/virtee/snpguest) | Guest and host images |
+| `BEACON_TAG` | [AMDEPYC/beacon](https://github.com/AMDEPYC/beacon) | Host images |
+| `SNPHOST_TAG` | [virtee/snphost](https://github.com/virtee/snphost) | Host images |
+
+The `.tags` file is passed to mkosi via `--env-file` so each build script uses the pre-fetched tag rather than calling the GitHub API individually. This avoids rate-limit issues when building multiple images (the GitHub API allows 60 unauthenticated requests/hour).
+
+Re-run `make tags` whenever you want to pick up a new release of one of the dependencies. The `.tags` file is not checked in, so it won't update automatically.
+
+If you hit rate limits, set a token first:
+
+```bash
+export GITHUB_TOKEN=$(gh auth token)
+make tags
+```
+
+> **Note**: In CI, the workflow fetches these same tags and injects them directly into mkosi configs, so `make tags` is only needed for local builds.
+
+### 2. Build images
+
 ```bash
 make list                    # show available images
 make host-fedora-41          # build a specific image


### PR DESCRIPTION
Building locally often gets you rate-limited by GH, since we do not support authenticated calls. Add a `make tags` option that pre-fetches the tags. Due to how mkosi handles environments, this is done by creating an environment file and passing it to the mkosi command.

This commit does not affect the normal CI image builds, as the images/Makefile is just for local development.