### PR TITLE
fix: README column match in cert matrix workflow

### DIFF
--- a/.github/workflows/update-certification-matrix.yml
+++ b/.github/workflows/update-certification-matrix.yml
@@ -157,7 +157,7 @@ jobs:
                   
                   if (headerIdx !== -1) {
                     const headers = readmeLines[headerIdx].split('|').map(h => h.trim()).filter(h => h);
-                    const readmeColumnIndex = headers.findIndex(h => h.includes(`${certVersion} Certification`));
+                    const readmeColumnIndex = headers.findIndex(h => h.includes(`EPYC ${procSeries}`));
                     
                     if (readmeColumnIndex !== -1) {
                       const readmeTableStart = headerIdx + 2;


### PR DESCRIPTION
The README table headers use [EPYC XXXX][cert-X.Y] format, not 'X.Y Certification'. The column lookup searched for '3.0 Certification' which never matched, silently skipping the README update while certifications.md was updated correctly.

Tested on my fork.