### PR TITLE
fix: add C++ build deps for cpuid-native on forky

### DIFF
--- a/images/host-debian-forky/mkosi.conf
+++ b/images/host-debian-forky/mkosi.conf
@@ -23,7 +23,9 @@ Packages=
 	openssh-server
 	xxd
 	python3
+	python3-dev
 	python3-pip
 	python3-emoji
+	g++
 	jq
 	avahi-daemon


### PR DESCRIPTION
Fix build issue with forky:
```
Building wheels for collected packages: cpuid-native
  Building wheel for cpuid-native (pyproject.toml): started
  Building wheel for cpuid-native (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Building wheel for cpuid-native (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      /tmp/pip-build-env-i0wreksa/overlay/local/lib/python3.14/dist-packages/setuptools/dist.py:765: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!
      
              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:
      
              License :: OSI Approved :: MIT License
      
              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************
      
      !!
        self._finalize_license_expression()
      running bdist_wheel
      running build
      running build_ext
      building 'cpuid_native' extension
      creating build/temp.linux-x86_64-cpython-314
      x86_64-linux-gnu-g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -I/usr/include/python3.14 -c cpuidmodule.cpp -o build/temp.linux-x86_64-cpython-314/cpuidmodule.o
      error: command 'x86_64-linux-gnu-g++' failed: No such file or directory
      [end of output]
```

Cause is Debian Forky started shipping Python 3.14 as of today 7/14/26. (python3-defaults 3.14.6-1 migrated to testing on 2026-07-14). https://tracker.debian.org/news/1774834/python3-defaults-3146-1-migrated-to-testing/

There is no pre-built cpuid-native wheel on PyPI for Python 3.14, so pip falls back to building from
source, requiring g++ and python3-dev.

https://tracker.debian.org/pkg/python3-defaults