### PR TITLE
Add openSUSE Leap 16.0 support

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo sed -i 's/noble/plucky/g' /etc/apt/sources.list.d/ubuntu.sources || true
+          sudo sed -i 's/noble/resolute/g' /etc/apt/sources.list.d/ubuntu.sources || true
           sudo apt update
           sudo apt install -y mkosi
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -79,6 +79,8 @@ jobs:
             release: "25.10"
           - distro: ubuntu
             release: "26.04"
+          - distro: opensuse
+            release: "16.0"
 
     steps:
       - name: Checkout

--- a/images/guest-opensuse-16.0/mkosi.conf
+++ b/images/guest-opensuse-16.0/mkosi.conf
@@ -1,0 +1,29 @@
+[Include]
+Include=../../modules/build/guest
+
+[Distribution]
+Distribution=opensuse
+Release=16.0
+RepositoryKeyFetch=yes
+
+[Content]
+Packages=
+        kernel-default
+        systemd
+        systemd-boot
+        systemd-networkd
+        systemd-resolved
+        systemd-journal-remote
+        zypper
+        udev
+        iputils
+        ca-certificates
+        p11-kit-tools
+        jq
+        patterns-devel-base-devel_basis
+        bind-utils
+        xxd
+        python3
+
+[Build]
+Environment=VERSION="16.0"

--- a/images/host-opensuse-16.0/mkosi.conf
+++ b/images/host-opensuse-16.0/mkosi.conf
@@ -1,0 +1,36 @@
+[Include]
+Include=../../modules/build/host
+
+[Distribution]
+Distribution=opensuse
+Release=16.0
+RepositoryKeyFetch=yes
+
+[Content]
+Packages=
+        kernel-default
+        systemd
+        systemd-boot
+        systemd-networkd
+        systemd-resolved
+        zypper
+        ca-certificates
+        p11-kit-tools
+        patterns-devel-base-devel_basis
+        NetworkManager
+        SUSEConnect
+        shadow
+        qemu
+        kernel
+        rpm
+        systemd-journal-remote
+        xxd
+        python3
+        python3-pip
+        python3-emoji
+        jq
+        avahi
+KernelCommandLine="iommu=nopt"
+
+[Build]
+Environment=VERSION="16.0"

--- a/images/host-opensuse-16.0/mkosi.conf
+++ b/images/host-opensuse-16.0/mkosi.conf
@@ -34,3 +34,4 @@ KernelCommandLine="iommu=nopt"
 
 [Build]
 Environment=VERSION="16.0"
+SandboxTrees=mkosi.pkgmngr

--- a/images/host-opensuse-16.0/mkosi.pkgmngr/etc/zypp/repos.d/virtualization.repo
+++ b/images/host-opensuse-16.0/mkosi.pkgmngr/etc/zypp/repos.d/virtualization.repo
@@ -1,0 +1,8 @@
+[Virtualization]
+name=Virtualization (16.0)
+enabled=1
+autorefresh=1
+baseurl=https://download.opensuse.org/repositories/Virtualization/16.0/
+gpgcheck=1
+gpgkey=https://download.opensuse.org/repositories/Virtualization/16.0/repodata/repomd.xml.key
+priority=90

--- a/images/host-opensuse-16.0/mkosi.pkgmngr/etc/zypp/zypp.conf
+++ b/images/host-opensuse-16.0/mkosi.pkgmngr/etc/zypp/zypp.conf
@@ -1,0 +1,2 @@
+[main]
+solver.allowVendorChange = true

--- a/images/host-opensuse-16.0/mkosi.prepare
+++ b/images/host-opensuse-16.0/mkosi.prepare
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "$1" == "final" ]]; then
+    zypper --non-interactive --gpg-auto-import-keys refresh Virtualization
+    zypper --non-interactive install --allow-vendor-change --from Virtualization qemu-ovmf-x86_64
+fi

--- a/modules/build/common/load-kernel-modules/mkosi.build
+++ b/modules/build/common/load-kernel-modules/mkosi.build
@@ -4,7 +4,7 @@ set -eux
 os_name=$(grep '^ID=' /buildroot/etc/os-release | cut -d'=' -f2 | tr -d '"')
 
 case "$os_name" in
-  debian|ubuntu|centos)
+  debian|ubuntu|centos|opensuse-leap)
     echo "Applying module configuration for $os_name"
     ;;
   *)

--- a/modules/build/common/mkosi.conf
+++ b/modules/build/common/mkosi.conf
@@ -1,6 +1,6 @@
 [Build]
 ToolsTreeDistribution=fedora
-ToolsTreeRelease=42
+ToolsTreeRelease=44
 ToolsTree=default
 
 [Output]
@@ -21,4 +21,5 @@ Include=./snpguest
 Include=./network
 Include=./network-fix
 Include=./load-kernel-modules
+Include=./systemd-conf
 

--- a/modules/build/common/network-fix/mkosi.build
+++ b/modules/build/common/network-fix/mkosi.build
@@ -6,7 +6,7 @@ resolv_conf_link="https://raw.githubusercontent.com/systemd/systemd/refs/heads/m
 os_name=$(grep '^ID=' /buildroot/etc/os-release | cut -d'=' -f2 | tr -d '"')
 
 case "$os_name" in
-  rocky|centos)
+  rocky|centos|opensuse-leap)
     ;;
   *)
     echo "Skipping resolv.conf update for $os_name"

--- a/modules/build/common/systemd-conf/mkosi.extra/usr/lib/systemd/system.conf.d/10-status-format.conf
+++ b/modules/build/common/systemd-conf/mkosi.extra/usr/lib/systemd/system.conf.d/10-status-format.conf
@@ -1,0 +1,2 @@
+[Manager]
+StatusUnitFormat=combined

--- a/sev_verify/cert_tests/c3_0/c3_0_0_0/attestation_test.py
+++ b/sev_verify/cert_tests/c3_0/c3_0_0_0/attestation_test.py
@@ -25,7 +25,7 @@ from sev_verify.vm_profile import VMProfile, VMProfileError
 
 vm_profile = VMProfile(
     image_path="",
-    memory_mb=2048,
+    memory_mb=4096,
 )
 
 def calculate_measurement(ctx: StepContext) -> StepHandlerResult:

--- a/sev_verify/vm_profile.py
+++ b/sev_verify/vm_profile.py
@@ -20,6 +20,7 @@ from typing import Any, TextIO
 DEFAULT_OVMF_CANDIDATES = (
     "/usr/share/ovmf/OVMF.amdsev.fd",
     "/usr/share/edk2/ovmf/OVMF.amdsev.fd",
+    "/usr/share/qemu/ovmf-x86_64-sev.bin",
 )
 
 

--- a/sev_verify/vm_profile.py
+++ b/sev_verify/vm_profile.py
@@ -34,7 +34,7 @@ def find_ovmf_path() -> str | None:
 
 DEFAULT_GUEST_ERROR_LOG = "/tmp/guest-error.log"
 DEFAULT_QEMU_BINARY = "qemu-system-x86_64"
-DEFAULT_MEMORY_MB = 2048
+DEFAULT_MEMORY_MB = 4096
 DEFAULT_VSOCK_CID = 3
 DEFAULT_VSOCK_PORT = 5000
 HOST_DATA_SIZE = 32


### PR DESCRIPTION
Implemented the following changes in this PR:

- Added host and guest image configurations for openSUSE Leap 16.0
- Configured OVMF package installation from openSUSE Virtualization repository
- Updated CI workflow to build and release openSUSE Leap 16.0 images
- Added systemd status format configuration module for cleaner boot output
- New images/guest-opensuse-16.0/ and images/host-opensuse-16.0/ configurations
- Added Virtualization repository for OVMF firmware package availability
- Updated vm_profile.py with openSUSE firmware path (/usr/share/qemu/ovmf-x86_64.bin)
- Increased guest memory from 1536 MB to 2048 MB for stability, to able to launch SNP guest on OpenSUSE Leap 16.0 distribution without "No disk space" issues when performing SNP tests on the guest.
- Fixed Ubuntu codename in workflow (plucky → resolute)

Please refer to the certificates in my forked repository for this PR: [SNP certificates for different OSes](https://github.com/LakshmiSaiHarika/snpcert/issues)