### PR TITLE
Distro: Add Fedora 44 Release for SEV Certification Workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -81,6 +81,8 @@ jobs:
             release: "26.04"
           - distro: opensuse
             release: "16.0"
+          - distro: fedora
+            release: "44"
 
     steps:
       - name: Checkout

--- a/images/guest-fedora-44/mkosi.conf
+++ b/images/guest-fedora-44/mkosi.conf
@@ -1,0 +1,23 @@
+[Include]
+Include=../../modules/build/guest
+
+[Distribution]
+Distribution=fedora
+Release=44
+
+[Content]
+Packages=
+    kernel
+    selinux-policy-targeted
+    systemd
+    systemd-boot-unsigned
+    systemd-networkd
+    systemd-resolved
+    systemd-journal-remote
+    jq
+    xxd
+    python3
+KernelCommandLine="selinux=0"
+
+[Build]
+Environment=VERSION="44"

--- a/images/host-fedora-41/mkosi.conf
+++ b/images/host-fedora-41/mkosi.conf
@@ -12,7 +12,7 @@ Packages=
     systemd-boot-unsigned
     systemd-networkd
     systemd-resolved
-    qemu
+    qemu-kvm-core
     edk2-ovmf
     dnf
     systemd-journal-remote

--- a/images/host-fedora-44/mkosi.conf
+++ b/images/host-fedora-44/mkosi.conf
@@ -1,0 +1,33 @@
+[Include]
+Include=../../modules/build/host
+
+[Distribution]
+Distribution=fedora
+Release=44
+
+[Content]
+Packages=
+    kernel
+    selinux-policy-targeted
+    systemd
+    systemd-boot-unsigned
+    systemd-networkd
+    systemd-resolved
+    qemu-kvm-core
+    edk2-ovmf
+    dnf
+    systemd-journal-remote
+    net-tools
+    openssh-server
+    xxd
+    python3
+    python3-devel
+    python3-pip
+    python3-emoji
+    jq
+    avahi
+    g++
+KernelCommandLine="selinux=0"
+
+[Build]
+Environment=VERSION="44"


### PR DESCRIPTION
In this PR, I added the Fedora 44 release to validate package support(QEMU, OVMF, kernel) for the SEV workflow.
To optimize the host image size under 1G, I added unused kernel modules to the `KernelExcludeModules` section.

For the Fedora 44 SEV certificate in my forked repository, refer to https://github.com/LakshmiSaiHarika/snpcert/issues/115.
Refer to my forked sev-certify repository issues tab for OS certificates generated with my PR branch: https://github.com/LakshmiSaiHarika/snpcert/issues