### PR TITLE
Fix: Update Certificate Workflow to create PR for opensuse-leap OS Release

### DIFF
--- a/.github/workflows/update-certification-matrix.yml
+++ b/.github/workflows/update-certification-matrix.yml
@@ -23,7 +23,7 @@ jobs:
             
             // Extract and validate labels
             const procLabel = issue.labels.find(l => l.name.match(/^proc-\d+$/i));
-            const distroLabel = issue.labels.find(l => l.name.match(/^os-[a-zA-Z]+(?:-[a-zA-Z0-9.]+)?$/i));
+            const distroLabel = issue.labels.find(l => l.name.match(/^os-[a-zA-Z]+(?:-[a-zA-Z0-9.]+)*$/i));
             if (!procLabel || !distroLabel) return console.log('Missing processor or OS label');
             
             const procSeries = procLabel.name.replace(/^proc-/i, '');

--- a/.github/workflows/update-certification-matrix.yml
+++ b/.github/workflows/update-certification-matrix.yml
@@ -2,7 +2,7 @@ name: Update Certification Matrix
 
 on:
   issues:
-    types: [opened]
+    types: [opened, milestoned]
 
 jobs:
   update-matrix:
@@ -219,7 +219,7 @@ jobs:
 
             // Find the OS label and processor label
             const osLabel = issue.labels.find(label =>
-              label.name.match(/^os-[a-zA-Z]+(?:-[a-zA-Z0-9.]+)?$/i)
+              label.name.match(/^os-[a-zA-Z]+(?:-[a-zA-Z0-9.]+)*$/i)
             );
             const procLabel = issue.labels.find(label =>
               label.name.match(/^proc-\d+$/i)


### PR DESCRIPTION
Earlier, in the Opensuse issues, the GH Action for the certificate workflow was missing, which is fixed in this PR.

In this PR, I added a fix for the regex expression to include the expression 'opensuse-leap' in issues.
Also, I included `milestoned` event to trigger the GH Action to update the certificate when a milestone is updated.

Refer to my updated opensuse issue in my forked repo to show the GH action for the cert workflow update: https://github.com/LakshmiSaiHarika/snpcert/issues/130
GH Bot generated PR Link: https://github.com/LakshmiSaiHarika/snpcert/pull/129